### PR TITLE
Release pipeline don't remove .git directories as gh cli needs them

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Sign pwsh scripts and modules
         shell: powershell
         run: |
-          Get-ChildItem -Path "." -Filter ".git*" -Force | ForEach-Object {Remove-Item -Path $_.FullName -Recurse -Force}
           $scripts = Get-ChildItem -Path . -Include *.ps1,*.psm1,*.psd1 -Recurse -ErrorAction Stop
           $vaultName = $env:VAULTNAME
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
Remove the ps scripts thats removing .git directories gh cli needs them for creating release.

## This PR fixes/adds/changes/removes

1. Removes the ps scripts thats removing .git directories gh cli needs them for creating release.

### Breaking Changes
N/A
## Testing Evidence
N/A

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/GuardrailsSolutionAccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/GuardrailsSolutionAccelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/GuardrailsSolutionAccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
