### PR TITLE
add module import pipeline to be triggered on PR raises

### DIFF
--- a/.github/workflows/test-module-import.yml
+++ b/.github/workflows/test-module-import.yml
@@ -1,0 +1,37 @@
+name: TestModuleImports
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test Module Imports
+      shell: powershell
+      run: |
+        $ErrorActionPreference = 'Stop'
+
+        $moduleFiles = Get-ChildItem -path ./* -recurse -include *.psm1
+        Write-Host "Count of module files: $($moduleFiles.count)"
+          
+        try {
+          ForEach ($moduleFile in $moduleFiles) {
+            Import-Module $moduleFile.Fullname -ErrorAction Stop
+          }
+        }
+        catch {
+          throw "Failed test import module '$moduleFile' with error: $_"
+        }
+
+        $importedModules = Get-Module
+        Write-Host "Imported modules: `n $($importedModules.Path | Out-String)"
+
+        $missingModules = $moduleFiles | Where-object {$_ -inotin ($importedModules).Path} 
+        If ($missingModules) {
+          throw "The following modules failed import test: $missingModules"
+        }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
Added a pipeline to be triggered on PR raises to test module imports.

## This PR fixes/adds/changes/removes

1. Added a pipeline to be triggered on PR raises to test module imports.

### Breaking Changes
N/A

## Testing Evidence

![image](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/assets/146129702/9a2a851b-cf10-4377-af2c-125f4d21a7b1)
## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
