### PR TITLE
Add etag to overwrite existing saved searches

### DIFF
--- a/setup/IaC/modules/loganalyticsworkspace.bicep
+++ b/setup/IaC/modules/loganalyticsworkspace.bicep
@@ -33,6 +33,7 @@ resource f2 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-08-01' 
   name: 'gr_data'
   parent: guardrailsLogAnalytics
   properties: {
+    etag: '*'
     category: 'gr_functions'
     displayName: 'gr_data'
     query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where ControlName_s has ctrlprefix and ReportTime_s == ReportTime and Required_s != tostring(showNonRequired)\n| where TimeGenerated > ago (24h)\n|join kind=inner (itsgcodes) on itsgcode_s\n| project ItemName=strcat(ItemName_s, iff(Required_s=="False"," (R)", " (M)")), Comments=Comments_s, Status=iif(tostring(ComplianceStatus_b)=="True", \'✔️ \', \'❌ \'),["ITSG Control"]=itsgcode_s, Mitigation=gr_geturl(replace_string(ctrlprefix," ",""),itsgcode_s)'
@@ -45,6 +46,7 @@ resource f1 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-08-01' 
   name: 'gr_geturl'
   parent: guardrailsLogAnalytics
   properties: {
+    etag: '*'
     category: 'gr_functions'
     displayName: 'gr_geturl'
     //query: 'let baseurl="${GRDocsBaseUrl}";\nlet Link=strcat(baseurl,control,"-", replace_string(replace_string(itsgcode,"(","-"),")",""),".md");\nLink\n'
@@ -58,6 +60,7 @@ resource f3 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-08-01' 
   name: 'gr_data567'
   parent: guardrailsLogAnalytics
   properties: {
+    etag: '*'
     category: 'gr_functions'
     displayName: 'gr_data567'
     query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where ControlName_s has ctrlprefix and ReportTime_s == ReportTime and Required_s != tostring(showNonRequired)\n| where TimeGenerated > ago (24h)\n|join kind=inner (itsgcodes) on itsgcode_s\n| project Type=Type_s, Name=DisplayName_s, ItemName=strcat(ItemName_s, iff(Required_s=="False"," (R)", " (M)")), Comments=Comments_s, Status=iif(tostring(ComplianceStatus_b)=="True", \'✔️ \', \'❌ \'),["ITSG Control"]=itsgcode_s, Mitigation=gr_geturl(replace_string(ctrlprefix," ",""),itsgcode_s)'


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
Added etag: '*' to overwrite existing saved searches. 
CAC Install throws an intermittent 409 conflict error
```
ServiceClient: Response status code does not indicate success - 409 (Conflict), for request - /Customer.svc/workspaces/cd2ab1c3-d71c-4d93-8b06-e6a0c82b73eb/CustomerConfiguration, due to reason - [Newer data exists in the Customer Configuration Store.].
```
## This PR fixes/adds/changes/removes

1. 409 error conflict while creating save searches.

### Breaking Changes

N/A

## Testing Evidence

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
