### PR TITLE
[Bugfix] - use single quotes instead of double due to escape issues

### DIFF
--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -559,7 +559,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 9\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has \"GUARDRAIL 9:\"  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['VNet Name']= column_ifexists('VNETName_s', ""), Status=iif(tostring(ComplianceStatus_b)==\"True\", '✔️ ', '❌ '), Comments=Comments_s,[\"ITSG Control\"]=itsgcode_s, Mitigation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s)\r\n",
+        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 9\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has \"GUARDRAIL 9:\"  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['VNet Name']=column_ifexists('VNETName_s', ''), Status=iif(tostring(ComplianceStatus_b)==\"True\", '✔️ ', '❌ '), Comments=Comments_s,[\"ITSG Control\"]=itsgcode_s, Mitigation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s)\r\n",
         "size": 0,
         "title": "GR 9",
         "timeContext": {

--- a/tools/CentralView/Modules/ingest-tenantsData/ingest-tenantsData.psm1
+++ b/tools/CentralView/Modules/ingest-tenantsData/ingest-tenantsData.psm1
@@ -65,7 +65,7 @@ GuardrailsCompliance_CL
     | where ControlName_s has ctrlprefix and ReportTime_s == "{0}"
     | where TimeGenerated > ago (12h)
     |join kind=inner (itsgcodes) on itsgcode_s
-    | project Mandatory=Required_s,ControlName_s, ['VNet Name']= column_ifexists('VNETName_s', ""), ItemName=ItemName_s, Status=iif(tostring(ComplianceStatus_b)=="True", 'Compliant', 'Non-Compliant'), ["ITSG Control"]=itsgcode_s, Definition=Definition_s,Mitigation=gr_geturl(replace_string(ctrlprefix," ",""),itsgcode_s)
+    | project Mandatory=Required_s,ControlName_s, ['VNet Name']= column_ifexists('VNETName_s', ''), ItemName=ItemName_s, Status=iif(tostring(ComplianceStatus_b)=="True", 'Compliant', 'Non-Compliant'), ["ITSG Control"]=itsgcode_s, Definition=Definition_s,Mitigation=gr_geturl(replace_string(ctrlprefix," ",""),itsgcode_s)
     | summarize Count=count('VNet Name') by Mandatory,ControlName_s, Status, ItemName,['ITSG Control']
 "@
     [PSCustomObject] $FinalObjectList = New-Object System.Collections.ArrayList


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
Query using double quotes will not be parsed correctly in workbook.
Using single quotes for empty string
closes #12 

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. Replace double quotes with single quotes

### Breaking Changes
N/A

## Testing Evidence
![image](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/assets/146129702/0290e6a8-0f6b-4c53-b3ec-6d108d559d47)

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
