### PR TITLE
[Bug fix] Fixing GR4 module compliance status

### DIFF
--- a/setup/modules.json
+++ b/setup/modules.json
@@ -396,7 +396,7 @@
     "localVariables": [
       {
         "Name": "DocumentName",
-        "Value": "SPNEnencryptedEmailToCSPMSentAttestation"
+        "Value": "SPNEncryptedEmailToCSPMSentAttestation"
       },
       {
         "Name": "itsgcode",


### PR DESCRIPTION
## Overview/Summary
GR4 control "CSPM encrypted email with credentials sent" compliance status shows incorrect status as the file not found. whereas the attestation file is in storage container.

![image](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/assets/147828743/639fdf9c-6f26-43f2-9d41-8cc1ae321ff5)

## This PR fixes/adds/changes/removes
This pull request fixes the filename typo in the json file.

### Breaking Changes
N/A

## Testing Evidence
![image](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/assets/147828743/ef2ff572-53e6-432f-acf4-2cf934cd985e)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
