### PR TITLE
BugFix - Update upload and download artifact version to V4

### DIFF
--- a/.github/workflows/auto-update-modules.yml
+++ b/.github/workflows/auto-update-modules.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Check Out
         uses: actions/checkout@v3
       - name: Download zipped modules and replace old ones
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name:  ${{ env.ARTIFACT_NAME }}
           path: ./psmodules

--- a/.github/workflows/auto-update-modules.yml
+++ b/.github/workflows/auto-update-modules.yml
@@ -126,7 +126,7 @@ jobs:
               }
           }
       - name: Publish artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ./psmodules/*.zip

--- a/.github/workflows/deploy_dev_env.yml
+++ b/.github/workflows/deploy_dev_env.yml
@@ -72,7 +72,7 @@ jobs:
               }
           }
       - name: Publish artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ./psmodules/*.zip

--- a/.github/workflows/deploy_dev_env.yml
+++ b/.github/workflows/deploy_dev_env.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Check out
         uses: actions/checkout@v3
       - name: Download zipped modules and replace old ones
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: ${{env.ARTIFACT_NAME}}
           path: ./psmodules

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -127,7 +127,7 @@ jobs:
               }
           }
       - name: Publish artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ github.workspace }}

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -139,7 +139,7 @@ jobs:
       contents: write
     steps:
       - name: Download signed ps scripts and zipped modules
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name:  ${{ env.ARTIFACT_NAME }}
           path: .        

--- a/.github/workflows/sign-scripts-development.yml
+++ b/.github/workflows/sign-scripts-development.yml
@@ -135,7 +135,7 @@ jobs:
               }
           }
       - name: Publish artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ./psmodules/*.zip

--- a/.github/workflows/sign-scripts-development.yml
+++ b/.github/workflows/sign-scripts-development.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Check Out
         uses: actions/checkout@v3
       - name: Download zipped modules and replace old ones
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name:  ${{ env.ARTIFACT_NAME }}
           path: ./psmodules


### PR DESCRIPTION
## Overview/Summary

This Pull Request updates the pipeline to use the latest versions of the `download` and `upload` artifacts, upgrading both to v4. This update ensures compatibility with recent enhancements and optimizations in the artifact handling process.

## This PR fixes/adds/changes/removes

1. Updated the `DownloadPipelineArtifact` task to use version `v4`.
2. Updated the `PublishPipelineArtifact` task to use version `v4`.
3. Adjusted related pipeline scripts and configurations to align with the new artifact task versions.

### Breaking Changes
N/A

## Testing Evidence

Testing was performed by running the updated pipeline in a staging environment. The following evidence confirms that the changes work as expected:

- Successful completion of the pipeline with the new artifact versions.
- Artifacts were correctly downloaded and uploaded with the updated tasks.
- No errors or unexpected behaviors were observed during the pipeline execution.

![image](https://github.com/user-attachments/assets/e979e45c-0be8-4d97-9500-7fb05bc30370)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [] Updated relevant and associated documentation.
- [] Ensured PowerShell module versions have been updated (manually or with the `./tools/Update-ModuleVersions.ps1` script)
