### PR TITLE
 [BugFix] - Fix Release pipeline - remove artifact requirement completely 

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -6,24 +6,26 @@ on:
 
 name: Azure CAC Release
 
-
 env:
   ARTIFACT_NAME: PowerShell.Workflows.Release.ScriptSigning
 
-
 jobs:
-  sign_scripts:
-    name: Sign, validate, test and publish PowerShell scripts as pipeline artifacts
+  release:
+    name: Sign, Test, and Release
     runs-on: windows-2019
     environment: test
     permissions:
       id-token: write
-      contents: read
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - name: Install AzureSignTool
         run: dotnet tool install --no-cache --global AzureSignTool --version 4.0.1
+
       - name: AZ Login
         uses: azure/login@v2
         with:
@@ -31,11 +33,12 @@ jobs:
           tenant-id: ${{ secrets.ENT_AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.ENT_AZURE_SUBSCRIPTION_ID }}
           enable-AzPSSession: true 
+
       - name: Azure token
         run: |
-            $az_token=$(az account get-access-token --scope https://vault.azure.net/.default --query accessToken --output tsv)
-            echo "::add-mask::$az_token"
-            echo "AZ_TOKEN=$az_token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $az_token=$(az account get-access-token --scope https://vault.azure.net/.default --query accessToken --output tsv)
+          echo "::add-mask::$az_token"
+          echo "AZ_TOKEN=$az_token" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Sign pwsh scripts and modules
         shell: powershell
@@ -45,7 +48,6 @@ jobs:
 
           foreach ($script in $scripts) {
               try {
-                    # sign script
                     azuresigntool.exe sign --verbose -kvu https://$vaultName.vault.azure.net/ -kvc $env:CERTNAME -kva ${{ env.AZ_TOKEN }} -fd sha256 -tr "http://timestamp.comodoca.com/rfc3161" $script.FullName
               }
               catch {
@@ -60,7 +62,6 @@ jobs:
         shell: powershell
         run: |
           $signatureStatuses = Get-ChildItem -r -i *.ps* | Get-AuthenticodeSignature
-
           Foreach ($signatureStatus in $signatureStatuses) {
             If ($signatureStatus.Status -eq 'HashMismatch') {
               throw "File '$($signatureStatus.Path)' has a hash status of '$($signatureStatus.status)'"
@@ -75,14 +76,13 @@ jobs:
               throw "File '$($signatureStatus.Path)' has an unhandled hash status of '$($signatureStatus.status)'"
             }
           }
+
       - name: Test Module Imports
         shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
-
           $moduleFiles = Get-ChildItem -path ./* -recurse -include *.psm1
           Write-Host "Count of module files: $($moduleFiles.count)"
-          
           try {
             ForEach ($moduleFile in $moduleFiles) {
               Import-Module $moduleFile.Fullname -ErrorAction Stop
@@ -91,74 +91,23 @@ jobs:
           catch {
             throw "Failed test import module '$moduleFile' with error: $_"
           }
-
           $importedModules = Get-Module
           Write-Host "Imported modules: `n $($importedModules.Path | Out-String)"
-
           $missingModules = $moduleFiles | Where-object {$_ -inotin ($importedModules).Path} 
           If ($missingModules) {
             throw "The following modules failed import test: $missingModules"
           }
-      - name: Zip Signed Modules
-        shell: powershell
+
+      - name: Archive code
         run: |
-          $moduleCodeFilesObjs = Get-ChildItem -Path .\src -Recurse -Include *.psm1 -Exclude '*-GSA*','*GuardrailsSolutionAcceleratorSetup*','*Deploy-GuardrailsSolutionAccelerator*'
-          Write-Host "'$($moduleCodeFilesObjs.count)' module manifest files "
-
-          ForEach ($moduleCodeFile in $moduleCodeFilesObjs) {
-              $moduleManifestFile = Get-Item -Path $moduleCodeFile.FullName.replace('psm1','psd1')
-              
-              If ($moduleCodeFilesObjs.FullName -icontains $moduleCodeFile.FullName -or $moduleCodeFilesObjs.FullName -icontains $moduleManifestFile.FullName) {
-                Write-Host "Module '$($moduleCodeFile.BaseName)' found, zipping module files..."
-
-                $destPath = "./psmodules/$($moduleCodeFile.BaseName).zip"
-
-                If ($moduleCodeFile.DIrectory.Name -eq 'Guardrails-Localization') {
-                  Compress-Archive -Path "$($moduleCodeFile.Directory)/*" -DestinationPath $destPath -Force
-                }
-                Else {
-                  $filesToZip = $moduleManifestFile,$moduleCodeFile
-                  Compress-Archive -Path $filesToZip -DestinationPath $destPath -Force
-                }
-
-              }
-              Else {
-                  Write-Host "Neither the manifest '$($moduleCodeFile.FullName.toLower())' or script file '$($moduleManifestFile.FullName.ToLower())' for module '$($moduleCodeFile.BaseName)' was changed, skipping zipping..."
-              }
-          }
-      - name: Publish artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ github.workspace }}
-  create_release:
-    name: Create Release
-    needs: sign_scripts
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Download signed ps scripts and zipped modules
-        uses: actions/download-artifact@v4
-        with:
-          name:  ${{ env.ARTIFACT_NAME }}
-          path: .        
-
-      - id: archive-code      
-        name: Archive code
-        run: |
-          mkdir -p release_assets
-          releaseName=$(basename ${{ github.ref }})
-          # Create a tarball (tgz) and a zip file of your code
-          tar --exclude='release_assets' --exclude='.git' --exclude='.github' -czvf release_assets/azure-cac-solution-$releaseName.tar.gz .
-          zip -r release_assets/azure-cac-solution-$releaseName.zip . -x "release_assets/*" -x ".git/*" -x ".github/*"
-          echo "releasename=$releaseName" >> $GITHUB_OUTPUT
+          $releaseName = $env:GITHUB_REF -replace 'refs/tags/', ''
+          mkdir release_assets
+          tar -czvf release_assets/azure-cac-solution-$releaseName.tar.gz --exclude='release_assets' --exclude='.git' --exclude='.github' .
+          Compress-Archive -Path . -DestinationPath release_assets/azure-cac-solution-$releaseName.zip -Exclude 'release_assets/*','.git/*','.github/*'
+          echo "RELEASE_NAME=$releaseName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Create Release
-        run: |
-          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref_type }}" == "tag" ]; then
-            gh release create ${{ github.ref }} --generate-notes --latest "./release_assets/azure-cac-solution-$RELEASE_NAME.tar.gz#Azure CAC Solution (tar.gz)" "./release_assets/azure-cac-solution-$RELEASE_NAME.zip#Azure CAC Solution (zip)" 
-          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NAME: ${{ steps.archive-code.outputs.releasename }}
+        run: |
+          gh release create $env:RELEASE_NAME --generate-notes --latest "./release_assets/azure-cac-solution-$env:RELEASE_NAME.tar.gz#Azure CAC Solution (tar.gz)" "./release_assets/azure-cac-solution-$env:RELEASE_NAME.zip#Azure CAC Solution (zip)"


### PR DESCRIPTION
## Overview/Summary

 Fix Release pipeline - remove artifact requirement completely 
Upload artifact v4 is not uploading .git folder result gh cli not working. 

## This PR fixes/adds/changes/removes

1. Upload artifact v4 is not uploading .git folder result gh cli not working. 
2. Removeing upload/download artifact and creating a single job
3. No need to zip signed modules as its already done part of pre release pipeline.

### Breaking Changes
N/A

## Testing Evidence
N/A

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
