### PR TITLE
[BugFix] Use zip instead of compress-archive for creating zip for release

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -103,7 +103,7 @@ jobs:
           $releaseName = $env:GITHUB_REF -replace 'refs/tags/', ''
           mkdir release_assets
           tar -czvf release_assets/azure-cac-solution-$releaseName.tar.gz --exclude='release_assets' --exclude='.git' --exclude='.github' .
-          Compress-Archive -Path . -DestinationPath release_assets/azure-cac-solution-$releaseName.zip -Exclude 'release_assets/*','.git/*','.github/*'
+          zip -r release_assets/azure-cac-solution-$releaseName.zip . -x "release_assets/*" -x ".git/*" -x ".github/*"
           echo "RELEASE_NAME=$releaseName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Create Release


### PR DESCRIPTION
## Overview/Summary

Use zip instead of compress-archive for creating zip for release
## This PR fixes/adds/changes/removes

1. Use zip instead of compress-archive for creating zip for release

### Breaking Changes
N/A

## Testing Evidence
N/A

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
