### PR TITLE
Adding manual deployment to dev for testing

### DIFF
--- a/.github/workflows/deploy_dev_env.yml
+++ b/.github/workflows/deploy_dev_env.yml
@@ -1,6 +1,7 @@
 name: Deploy to Dev environment upon Release
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: [Azure CAC Release]
     types: 

--- a/setup/IaC/modules/automationaccount.bicep
+++ b/setup/IaC/modules/automationaccount.bicep
@@ -474,7 +474,7 @@ resource guardrailsAC 'Microsoft.Automation/automationAccounts@2021-06-22' = if 
     }
   }
 
-  resource module45 'modules' = if (newDeployment || updatePSModules) {
+  resource module47 'modules' = if (newDeployment || updatePSModules) {
     name: 'Check-ServiceHealthAlerts'
     properties: {
       contentLink: {


### PR DESCRIPTION
# Pull Request: Adding Manual Deployment to Dev for Testing

## Overview/Summary

This PR introduces changes to enable manual deployment to the development environment for testing purposes. The changes ensure that the deployment can be triggered manually via `workflow_dispatch` for increased flexibility and testing capabilities.

## This PR fixes/adds/changes/removes

1. Added the `workflow_dispatch` event to allow manual triggering of the deployment workflow.

### Breaking Changes

None.

## Testing Evidence

1. Verified that the `workflow_dispatch` event successfully triggers the deployment workflow.

### Screenshot of Changes

N/A
---

## Checklist

As part of this Pull Request I have:

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the [`main` branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Ensured PowerShell module versions have been updated (manually or with the `./tools/Update-ModuleVersions.ps1` script).
