### PR TITLE
[Cleanup] GR7 Removing old attestation control

### DIFF
--- a/setup/modules.json
+++ b/setup/modules.json
@@ -627,35 +627,6 @@
     ]
   },
   {
-    "ModuleName": "Check-DocumentExistsInStorage",
-    "Control": "Guardrails7",
-    "ModuleType": "Builtin",
-    "Status": "Enabled",
-    "Required": "True",
-    "Profiles": [2, 3, 4, 5, 6],
-    "Script": "Check-DocumentExistsInStorage -StorageAccountName $vars.storageaccountname -ContainerName $vars.containerName -ResourceGroupName $ResourceGroupName -SubscriptionID $SubID -DocumentName $vars.DocumentName -ControlName $msgTable.CtrName7 -ItemName $msgTable.enableTLS12 -MsgTable $msgTable -ReportTime $ReportTime -itsgcode $vars.itsgcode -CloudUsageProfiles $cloudUsageProfilesString -ModuleProfiles $ModuleProfilesString",
-    "variables": [
-      {
-        "Name": "storageAccountName",
-        "Value": "StorageAccountName"
-      },
-      {
-        "Name": "containerName",
-        "Value": "ContainerName"
-      }
-    ],
-    "localVariables": [
-      {
-        "Name": "DocumentName",
-        "Value": "TLS12EnabledAttestation"
-      },
-      {
-        "Name": "itsgcode",
-        "Value": "SC8"
-      }
-    ]
-  },
-  {
     "ModuleName": "Get-SubnetComplianceInformation",
     "Control": "Guardrails8",
     "ModuleType": "Builtin",

--- a/src/GuardRails-Localization/GR-ComplianceChecks-Msgs.psd1
+++ b/src/GuardRails-Localization/GR-ComplianceChecks-Msgs.psd1
@@ -190,7 +190,7 @@ hasNonComplianceResounce = {0} out of the {1} applicable resources are non-compl
 
 
 # GuardRail #7
-enableTLS12 = TLS 1.2+ is enabled whereever possible to secure data in transit
+
 appGatewayCertValidity = Application Gateway Certificate Validity
 noSslListenersFound = No SSL listener found/configured for Application Gateway: {0}. 
 expiredCertificateFound = Expired certificate found for listener '{0}' in Application Gateway '{1}'.

--- a/src/GuardRails-Localization/fr-CA/GR-ComplianceChecks-Msgs.psd1
+++ b/src/GuardRails-Localization/fr-CA/GR-ComplianceChecks-Msgs.psd1
@@ -191,7 +191,7 @@ hasNonComplianceResounce = {0} des ressources {1} applicables ne sont pas confor
 
 
 # GuardRail #7
-enableTLS12 = TLS 1.2+ est activé dans la mesure du possible pour sécuriser les données en transit
+
 appGatewayCertValidity = Validité du certificat : Passerelle d'application
 noSslListenersFound = Aucun écouteur Secure Socket Layer (SSL) trouvé/configuré pour la passerelle d'application : {0}. 
 expiredCertificateFound = Certificat expiré trouvé pour l'écouteur '{0}' dans la passerelle d'application '{1}'. 


### PR DESCRIPTION
## Overview/Summary

This pull request removes the outdated attestation control. "TLS 1.2+ is enabled whereever possible to secure data in transit (M)".

## This PR fixes/adds/changes/removes

This pull request removes the outdated attestation control. "TLS 1.2+ is enabled whereever possible to secure data in transit (M)" and its associated components

### Breaking Changes
N/A

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
