### PR TITLE
GR4 | Validation 2 | FinOps control needs to be "recommended" until/ if it becomes mandated

### DIFF
--- a/setup/modules.json
+++ b/setup/modules.json
@@ -439,7 +439,7 @@
     "Control": "Guardrails4",
     "ModuleType": "Builtin",
     "Status": "Enabled",
-    "Required": "True",
+    "Required": "False",
     "Profiles": [1, 2, 3, 4, 5, 6],
     "Script": "Check-FinOpsToolStatus -ControlName $msgTable.CtrName4 -ItemName $msgTable.FinOpsToolStatus -MsgTable $msgTable -ReportTime $ReportTime -itsgcode $vars.itsgcode -CloudUsageProfiles $cloudUsageProfilesString -ModuleProfiles $ModuleProfilesString",
     "localVariables": [


### PR DESCRIPTION
## Overview/Summary

GR4 FinOps control is changed to recommended until further notice

## This PR fixes/adds/changes/removes

1. modules.json
2. *Replace me*
3. *Replace me*

### Breaking Changes

No breaking changes

## Testing Evidence

N/A

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
