### PR TITLE
[Enhancement] GR9 | Validation 4 | List of non-compliant storage accounts missing

### DIFF
--- a/setup/IaC/modules/automationaccount.bicep
+++ b/setup/IaC/modules/automationaccount.bicep
@@ -392,7 +392,7 @@ resource guardrailsAC 'Microsoft.Automation/automationAccounts@2021-06-22' = if 
     properties: {
       contentLink: {
         uri: '${ModuleBaseURL}/Check-StorageAccountTLSversion.zip'
-        version: '1.0.2'
+        version: '1.0.3'
       }
     }
   }

--- a/src/GUARDRAIL 7 PROTECTION OF DATA-IN-TRANSIT/Audit/Check-StorageAccountTLSversion.psd1
+++ b/src/GUARDRAIL 7 PROTECTION OF DATA-IN-TRANSIT/Audit/Check-StorageAccountTLSversion.psd1
@@ -14,7 +14,7 @@
 RootModule = 'Check-StorageAccountTLSversion'
 
 # Version number of this module.
-ModuleVersion = '1.0.2'
+ModuleVersion = '1.0.3'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/GUARDRAIL 7 PROTECTION OF DATA-IN-TRANSIT/Audit/Check-StorageAccountTLSversion.psm1
+++ b/src/GUARDRAIL 7 PROTECTION OF DATA-IN-TRANSIT/Audit/Check-StorageAccountTLSversion.psm1
@@ -125,7 +125,7 @@ function Verify-TLSForStorageAccount {
             $nonCompliantStorageAccountNames = ($nonCompliantAccounts | 
                 Select-Object -ExpandProperty StorageAccountName) -join ', '
             Write-Verbose "Storage accounts which are using TLS1.1 or less: $nonCompliantStorageAccountNames"
-            $commentsArray = @($msgTable.isNotCompliant, $msgTable.storageAccNotValidTLS)
+            $commentsArray = @($msgTable.isNotCompliant, $msgTable.storageAccNotValidTLS, $msgTable.storageAccNotValidList -f $nonCompliantStorageAccountNames)
         }
     }
     catch {

--- a/src/GuardRails-Localization/GR-ComplianceChecks-Msgs.psd1
+++ b/src/GuardRails-Localization/GR-ComplianceChecks-Msgs.psd1
@@ -215,6 +215,7 @@ dataInTransit = PROTECTION OF DATA-IN-TRANSIT
 storageAccTLS12 = Storage Accounts TLS 1.2
 storageAccValidTLS = All storage accounts are using TLS1.2 or higher. 
 storageAccNotValidTLS= One or more storage accounts are using TLS1.1 or less. Update the storage accounts to TLS1.2 or higher.
+storageAccNotValidList = The following storage accounts are not valid: {0}
 
 functionAppHttpsConfig = Azure Functions: HTTPS Application Configuration
 

--- a/src/GuardRails-Localization/fr-CA/GR-ComplianceChecks-Msgs.psd1
+++ b/src/GuardRails-Localization/fr-CA/GR-ComplianceChecks-Msgs.psd1
@@ -217,6 +217,7 @@ dataInTransit = PROTECTION DES DONNÉES-EN-TRANSIT
 storageAccTLS12 = Comptes de stockage TLS 1.2
 storageAccValidTLS = Tous les comptes de stockage utilisent TLS1.2 ou version ultérieure. 
 storageAccNotValidTLS = Un ou plusieurs comptes de stockage utilisent TLS1.1 ou une version antérieure. Mettez à jour les comptes de stockage vers TLS1.2 ou version ultérieure.
+storageAccNotValidList = Les comptes de stockage suivants ne sont pas valides: {0}
 
 functionAppHttpsConfig = « Azure Functions » : Configuration d'application HTTPS
 


### PR DESCRIPTION
## Overview/Summary

New compliance message which will list all of the non compliant storage accounts if any exist

Closes #338 

## This PR fixes/adds/changes/removes

1. Check-StorageAccountTLSversion psm and psd files
2. GR-ComplianceChecks-Msgs en and fr versions
3. automationaccount.bicep module version update

### Breaking Changes

N/A

## Testing Evidence

Non compliant storage accounts can now be listed in compliance messages

![image](https://github.com/user-attachments/assets/27f6b746-4670-440a-9878-19b25cf70365)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
