### PR TITLE
[Enhancement] GR11 V4 Compliance Message Update for Defender for Cloud

### DIFF
--- a/src/GuardRails-Localization/GR-ComplianceChecks-Msgs.psd1
+++ b/src/GuardRails-Localization/GR-ComplianceChecks-Msgs.psd1
@@ -306,7 +306,7 @@ NotAllSubsHaveDefenderPlans = The following subscription(s) lack a defender plan
 errorRetrievingNotifications = Defender alert notifications for the subscription(s) are not configured. Ensure they match the Remediation Guidance requirements.
 EmailsOrOwnerNotConfigured = Defender alert notifications for the subscription do not include at least two email addresses or subscription owners. Configure this to ensure alerts are sent correctly.
 AlertNotificationNotConfigured = Defender alert notifications are incorrect. Set the severity to Medium or Low and review the Remediation Guidance.
-AttackPathNotifictionNotConfigured = Defender alerts must include attack path notifications. Ensure this is configured for each subscription's alerts per the Remediation Guidance.
+AttackPathNotificationNotConfigured = Defender alerts must include attack path notifications. Ensure that the severity is set to Medium or Low for each subscription's alerts, following the guidelines provided in the Remediation Guidance.
 DefenderCompliant = MS Defender for Cloud is enabled for all subscriptions, and email notifications are properly configured.
 
 monitoringChecklist = Monitoring Checklist: Use Cases

--- a/src/GuardRails-Localization/fr-CA/GR-ComplianceChecks-Msgs.psd1
+++ b/src/GuardRails-Localization/fr-CA/GR-ComplianceChecks-Msgs.psd1
@@ -311,8 +311,7 @@ NotAllSubsHaveDefenderPlans = Le(s) abonnement(s) suivant(s) n'a/n'ont pas de pl
 errorRetrievingNotifications = Les notifications d'alerte MS Defender pour le ou les abonnements ne sont pas configurées. Assurez-vous qu'elles correspondent aux exigences du guide de Remédiation.
 EmailsOrOwnerNotConfigured = Les notifications d'alerte MS Defender pour l'abonnement n'incluent pas au moins deux adresses courriel ou propriétaires d'abonnement. Configurez les pour s'assurer que les alertes sont envoyées correctement
 AlertNotificationNotConfigured = Les notifications d'alerte MS Defender sont incorrectes. Définissez la gravité à Moyen ou Faible et passez en revue le Guide de Remédiation.
-AttackPathNotifictionNotConfigured = Les alertes MS Defender doivent inclure des notifications de chemin d'attaque. Assurez-vous qu'elles sont configurées pour les alertes de chaque abonnement conformément aux instructions du Guide de Remédiation
-DefenderCompliant = MS Defender pour l'infonuagique est activé pour tous les abonnements et les notifications par courriel sont correctement configurées.
+AttackPathNotificationNotConfigured = Les alertes Defender doivent inclure des notifications de chemin d'attaque. Assurez-vous que la gravité est définie à Moyen ou Faible pour les alertes de chaque abonnement, selon les instructions fournies dans le guide de Remédiation.
 
 
 # GuardRail #12


### PR DESCRIPTION
## Overview/Summary

Updated the compliance message for GR11 Attack path notification settings

Closes #409 

## This PR fixes/adds/changes/removes

1. GR-ComplianceChecks-Msgs psm and psd file

### Breaking Changes

N/A

## Testing Evidence

N/A

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
