### PR TITLE
Disable GR4: FinOps Tool Status (R) Until GC Wide Roll Out

### DIFF
--- a/setup/modules.json
+++ b/setup/modules.json
@@ -438,7 +438,7 @@
     "ModuleName": "Check-FinOpsToolStatus",
     "Control": "Guardrails4",
     "ModuleType": "Builtin",
-    "Status": "Enabled",
+    "Status": "Disabled",
     "Required": "False",
     "Profiles": [1, 2, 3, 4, 5, 6],
     "Script": "Check-FinOpsToolStatus -ControlName $msgTable.CtrName4 -ItemName $msgTable.FinOpsToolStatus -MsgTable $msgTable -ReportTime $ReportTime -itsgcode $vars.itsgcode -CloudUsageProfiles $cloudUsageProfilesString -ModuleProfiles $ModuleProfilesString",


### PR DESCRIPTION
## Overview/Summary

Disable GR4: FinOps Tool Status (R) Until GC Wide Roll Out

## This PR fixes/adds/changes/removes

1. modules.json updated


### Breaking Changes

N/A

## Testing Evidence

N/A

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
