### PR TITLE
Config.json: Default template value for AllowedLocationInitiativeId

### DIFF
--- a/setup/config.json
+++ b/setup/config.json
@@ -10,7 +10,7 @@
   "SSCReadOnlyServicePrincipalNameAPPID": "00000000-0000-0000-0000-000000000000",
   "pbmmPolicyID": "4c4a5f27-de81-430b-b4e5-9cbd50595a87",
   "allowedLocationPolicyId": "e56962a6-4747-49cd-b67b-bf8b01975c4c",
-  "allowedLocationInitiativeId": "/providers/microsoft.management/managementgroups/252afaf3-eb71-4f05-8da2-279c8b2466b7/providers/microsoft.authorization/policysetdefinitions/6c7429039715412f9438cb15",
+  "allowedLocationInitiativeId": "N/A",
   "departmentNumber": "",
   "cbsSubscriptionName": "N/A",
   "securityLAWResourceId": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxx/resourceGroups/xxxxx/providers/Microsoft.OperationalInsights/workspaces/xxxxxxx",

--- a/setup/config.json
+++ b/setup/config.json
@@ -10,7 +10,7 @@
   "SSCReadOnlyServicePrincipalNameAPPID": "00000000-0000-0000-0000-000000000000",
   "pbmmPolicyID": "4c4a5f27-de81-430b-b4e5-9cbd50595a87",
   "allowedLocationPolicyId": "e56962a6-4747-49cd-b67b-bf8b01975c4c",
-  "allowedLocationInitiativeId": "N/A",
+  "allowedLocationInitiativeId": "/providers/microsoft.management/managementgroups/252afaf3-eb71-4f05-8da2-279c8b2466b7/providers/microsoft.authorization/policysetdefinitions/6c7429039715412f9438cb15",
   "departmentNumber": "",
   "cbsSubscriptionName": "N/A",
   "securityLAWResourceId": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxx/resourceGroups/xxxxx/providers/Microsoft.OperationalInsights/workspaces/xxxxxxx",


### PR DESCRIPTION
## Overview/Summary

Config.json: Default template value for AllowedLocationInitiativeId as N/A

## This PR fixes/adds/changes/removes

1. config.json

### Breaking Changes

N/A

## Testing Evidence

Not required, just need successful deployment run

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
