### PR TITLE
[Enhacement] French localization of some of the workbook UI elements

### DIFF
--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -163,6 +163,11 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibility": {
+        "parameterName": "AlwaysHidden",
+        "comparison": "isEqualTo",
+        "value": "true"
+      },
       "name": "parameters - locale"
     },
     {
@@ -181,6 +186,7 @@
               "additionalResourceOptions": [],
               "showDefault": false
             },
+            "defaultValue": "Other",
             "jsonData": "[\n    { \"value\":\"Other\", \"label\":\"Yes\" },\n    { \"value\":\"False\", \"label\":\"No\", \"selected\":true }\n]",
             "timeContext": {
               "durationMs": 86400000
@@ -188,7 +194,7 @@
             "value": "Other"
           }
         ],
-        "style": "pills",
+        "style": "above",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
@@ -215,6 +221,7 @@
               "additionalResourceOptions": [],
               "showDefault": false
             },
+            "defaultValue": "Other",
             "jsonData": "[\n    { \"value\":\"Other\", \"label\":\"Oui\" },\n    { \"value\":\"False\", \"label\":\"Non\", \"selected\":true }\n]",
             "timeContext": {
               "durationMs": 86400000
@@ -222,7 +229,7 @@
             "value": "Other"
           }
         ],
-        "style": "pills",
+        "style": "above",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
@@ -1323,4 +1330,3 @@
     }
   ],
   "fallbackResourceIds": [
-

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -70,9 +70,9 @@
             "timeContext": {
               "durationMs": 86400000
             },
+            "defaultValue": "",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "2023-01-16 19:55:14"
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "pills",
@@ -113,9 +113,9 @@
             "timeContext": {
               "durationMs": 86400000
             },
+            "defaultValue": "",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "2023-01-16 19:55:14"
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "pills",

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -1300,7 +1300,3 @@
     }
   ],
   "fallbackResourceIds": [
-    "/subscriptions/{Subscription}/resourceGroups/{ResourceGroup}/providers/Microsoft.OperationalInsights/workspaces/{Workspace}"
-  ],
-  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
-}

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -11,7 +11,6 @@
             "version": "KqlParameterItem/1.0",
             "name": "initialLocale",
             "type": 1,
-            "isRequired": false,
             "query": "GR_TenantInfo_CL | top 1 by TimeGenerated desc | project initialLocale = coalesce(locale_s, \"en-CA\")",
             "isHiddenWhenLocked": true,
             "queryType": 0,
@@ -40,7 +39,7 @@
     {
       "type": 1,
       "content": {
-        "json": "## Accélérateur de mesures de protection\n\nSélectionnez l'heure du rapport et choisissez si les articles recommandés sont affichés.\n\n(M) = Obligatoire / (R) = Recommandé",
+        "json": "## Acc\u00e9l\u00e9rateur de mesures de protection\n\nS\u00e9lectionnez l'heure du rapport et choisissez si les articles recommand\u00e9s sont affich\u00e9s.\n\n(M) = Obligatoire / (R) = Recommand\u00e9",
         "style": "info"
       },
       "conditionalVisibility": {
@@ -74,27 +73,19 @@
             },
             "defaultValue": "value::1",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "2023-01-16 19:55:14"
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "pills",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isNotEqualTo",
-          "value": "information"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "parameters - 1 - English"
+      "name": "parameters - 1 - English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isNotEqualTo",
+        "value": "information"
+      }
     },
     {
       "type": 9,
@@ -120,27 +111,19 @@
             },
             "defaultValue": "value::1",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "2023-01-16 19:55:14"
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "pills",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isNotEqualTo",
-          "value": "information"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "parameters - 1 - French"
+      "name": "parameters - 1 - French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isNotEqualTo",
+        "value": "information"
+      }
     },
     {
       "type": 9,
@@ -152,7 +135,6 @@
             "version": "KqlParameterItem/1.0",
             "name": "currentLocale",
             "type": 1,
-            "isRequired": false,
             "query": "GR_TenantInfo_CL | where ReportTime_s == \"{RunTime}\" | top 1 by TimeGenerated desc | project currentLocale = coalesce(locale_s, \"en-CA\")",
             "isHiddenWhenLocked": true,
             "queryType": 0,
@@ -214,7 +196,7 @@
             "id": "c90ebce2-9568-40ee-82cd-a8fd774f2e6b",
             "version": "KqlParameterItem/1.0",
             "name": "RequiredYesNo",
-            "label": "Afficher les contrôles recommandés",
+            "label": "Afficher les contr\u00f4les recommand\u00e9s",
             "type": 10,
             "isRequired": true,
             "typeSettings": {
@@ -500,7 +482,6 @@
         "version": "KqlItem/1.0",
         "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(\"GUARDRAIL 1\",\"{RunTime}\", \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -526,19 +507,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr1"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr1-English"
+      "name": "Gr1-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr1"
+      }
     },
     {
       "type": 9,
@@ -552,7 +526,6 @@
             "label": "Show Non-MFA Users",
             "type": 10,
             "isRequired": true,
-            "value": "no",
             "typeSettings": {
               "additionalResourceOptions": []
             },
@@ -579,7 +552,6 @@
         "version": "KqlItem/1.0",
         "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(\"MESURE DE PROTECTION 1\",\"{RunTime}\", \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -598,19 +570,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr1"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr1-French"
+      "name": "Gr1-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr1"
+      }
     },
     {
       "type": 3,
@@ -624,19 +589,12 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr1"
-        },
-        {
-          "parameterName": "showNonMfa",
-          "comparison": "isEqualTo",
-          "value": "yes"
-        }
-      ],
-      "name": "query - Non-MFA Users"
+      "name": "query - Non-MFA Users",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr1"
+      }
     },
     {
       "type": 3,
@@ -644,7 +602,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"GUARDRAIL 2\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 1,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -670,19 +627,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr2"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr2-English"
+      "name": "Gr2-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr2"
+      }
     },
     {
       "type": 9,
@@ -723,7 +673,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"MESURE DE PROTECTION 2\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 1,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -742,19 +691,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr2"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr2-French"
+      "name": "Gr2-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr2"
+      }
     },
     {
       "type": 3,
@@ -768,19 +710,12 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr2"
-        },
-        {
-          "parameterName": "su",
-          "comparison": "isEqualTo",
-          "value": "yes"
-        }
-      ],
-      "name": "query - 17"
+      "name": "query - 17",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr2"
+      }
     },
     {
       "type": 9,
@@ -818,7 +753,7 @@
     {
       "type": 1,
       "content": {
-        "json": "⚠️ Only the first 20 users without group assignments are shown below.",
+        "json": "\u26a0\ufe0f Only the first 20 users without group assignments are shown below.",
         "style": "info"
       },
       "conditionalVisibility": {
@@ -840,27 +775,19 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr2"
-        },
-        {
-          "parameterName": "suwg",
-          "comparison": "isEqualTo",
-          "value": "yes"
-        }
-      ],
-      "name": "query - 18"
+      "name": "query - 18",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr2"
+      }
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 3\", \"GUARDRAIL 3\"),\"{RunTime}\",  \"{RequiredYesNo}\")",
+        "query": "gr_data(\"GUARDRAIL 3\",\"{RunTime}\",  \"{RequiredYesNo}\")",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -886,19 +813,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr3"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr3-English"
+      "name": "Gr3-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr3"
+      }
     },
     {
       "type": 3,
@@ -906,7 +826,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"MESURE DE PROTECTION 3\",\"{RunTime}\",  \"{RequiredYesNo}\")",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -925,19 +844,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr3"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr3-French"
+      "name": "Gr3-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr3"
+      }
     },
     {
       "type": 3,
@@ -945,7 +857,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"GUARDRAIL 4\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -971,19 +882,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr4"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr4-English"
+      "name": "Gr4-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr4"
+      }
     },
     {
       "type": 3,
@@ -991,7 +895,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"MESURE DE PROTECTION 4\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1010,19 +913,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr4"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr4-French"
+      "name": "Gr4-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr4"
+      }
     },
     {
       "type": 3,
@@ -1030,7 +926,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data567(\"GUARDRAIL 5\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1054,19 +949,12 @@
           }
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr5"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr5-English"
+      "name": "Gr5-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr5"
+      }
     },
     {
       "type": 3,
@@ -1074,7 +962,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data567(\"MESURE DE PROTECTION 5\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1092,19 +979,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr5"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr5-French"
+      "name": "Gr5-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr5"
+      }
     },
     {
       "type": 3,
@@ -1112,7 +992,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data567(\"GUARDRAIL 6\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1137,19 +1016,12 @@
           }
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr6"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr6-English"
+      "name": "Gr6-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr6"
+      }
     },
     {
       "type": 3,
@@ -1157,7 +1029,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data567(\"MESURE DE PROTECTION 6\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1176,19 +1047,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr6"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr6-French"
+      "name": "Gr6-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr6"
+      }
     },
     {
       "type": 3,
@@ -1196,7 +1060,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data567(\"GUARDRAIL 7\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1220,19 +1083,12 @@
           }
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr7"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr7-English"
+      "name": "Gr7-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr7"
+      }
     },
     {
       "type": 3,
@@ -1240,7 +1096,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data567(\"MESURE DE PROTECTION 7\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1258,27 +1113,19 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr7"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr7-French"
+      "name": "Gr7-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr7"
+      }
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 8\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['Subnet Name']=SubnetName_s, Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s,[\"ITSG Control\"]=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')\r\n| sort by Status asc",
+        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 8\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['Subnet Name']=SubnetName_s, Status=case(ComplianceStatus_b == true, \"\u2714\ufe0f\", ComplianceStatus_b == false, \"\u274c\", \"\u2796\"), Comments=Comments_s,[\"ITSG Control\"]=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')\r\n| sort by Status asc",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1302,27 +1149,19 @@
           }
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr8"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr8-English"
+      "name": "Gr8-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr8"
+      }
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"MESURE DE PROTECTION 8\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['Subnet Name']=SubnetName_s, Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s,[\"ITSG Control\"]=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')\r\n| sort by Status asc",
+        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"MESURE DE PROTECTION 8\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['Subnet Name']=SubnetName_s, Status=case(ComplianceStatus_b == true, \"\u2714\ufe0f\", ComplianceStatus_b == false, \"\u274c\", \"\u2796\"), Comments=Comments_s,[\"ITSG Control\"]=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')\r\n| sort by Status asc",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1346,27 +1185,19 @@
           }
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr8"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr8-French"
+      "name": "Gr8-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr8"
+      }
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 9\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['VNet Name']=column_ifexists('VNETName_s', ''), Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s, ['ITSG Control']=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')",
+        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 9\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['VNet Name']=column_ifexists('VNETName_s', ''), Status=case(ComplianceStatus_b == true, \"\u2714\ufe0f\", ComplianceStatus_b == false, \"\u274c\", \"\u2796\"), Comments=Comments_s, ['ITSG Control']=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1398,27 +1229,19 @@
           }
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr9"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr9-English"
+      "name": "Gr9-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr9"
+      }
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"MESURE DE PROTECTION 9\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['VNet Name']=column_ifexists('VNETName_s', ''), Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s, ['ITSG Control']=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')",
+        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"MESURE DE PROTECTION 9\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['VNet Name']=column_ifexists('VNETName_s', ''), Status=case(ComplianceStatus_b == true, \"\u2714\ufe0f\", ComplianceStatus_b == false, \"\u274c\", \"\u2796\"), Comments=Comments_s, ['ITSG Control']=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1450,19 +1273,12 @@
           }
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr9"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr9-French"
+      "name": "Gr9-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr9"
+      }
     },
     {
       "type": 3,
@@ -1470,7 +1286,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"GUARDRAIL 10\",\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 4,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1496,19 +1311,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr10"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr10-English"
+      "name": "Gr10-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr10"
+      }
     },
     {
       "type": 3,
@@ -1516,7 +1324,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"MESURE DE PROTECTION 10\",\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 4,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1535,19 +1342,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr10"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr10-French"
+      "name": "Gr10-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr10"
+      }
     },
     {
       "type": 3,
@@ -1555,7 +1355,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data11(\"GUARDRAIL 11\",\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 1,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1587,19 +1386,12 @@
           }
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr11"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr11-English"
+      "name": "Gr11-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr11"
+      }
     },
     {
       "type": 3,
@@ -1607,7 +1399,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data11(\"MESURE DE PROTECTION 11\",\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 1,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1626,19 +1417,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr11"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr11-French"
+      "name": "Gr11-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr11"
+      }
     },
     {
       "type": 3,
@@ -1646,7 +1430,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"GUARDRAIL 12\",\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 4,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1672,19 +1455,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr12"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr12-English"
+      "name": "Gr12-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr12"
+      }
     },
     {
       "type": 3,
@@ -1692,7 +1468,6 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"MESURE DE PROTECTION 12\",\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 4,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1711,19 +1486,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr12"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr12-French"
+      "name": "Gr12-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr12"
+      }
     },
     {
       "type": 3,
@@ -1731,7 +1499,6 @@
         "version": "KqlItem/1.0",
         "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(\"GUARDRAIL 13\",\"{RunTime}\", \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1757,19 +1524,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr13"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr13-English"
+      "name": "Gr13-English",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr13"
+      }
     },
     {
       "type": 3,
@@ -1777,7 +1537,6 @@
         "version": "KqlItem/1.0",
         "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(\"MESURE DE PROTECTION 13\",\"{RunTime}\", \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1796,19 +1555,12 @@
           ]
         }
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isEqualTo",
-          "value": "gr13"
-        },
-        {
-          "parameterName": "initialLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "Gr13-French"
+      "name": "Gr13-French",
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "gr13"
+      }
     },
     {
       "type": 3,

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -291,7 +291,7 @@
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
             "linkLabel": "GUARDRAIL 6",
-            "subTarget": "test6",
+            "subTarget": "gr6",
             "style": "link"
           },
           {
@@ -418,7 +418,7 @@
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
             "linkLabel": "MESURE 6",
-            "subTarget": "test6",
+            "subTarget": "gr6",
             "style": "link"
           },
           {
@@ -498,7 +498,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(\"GUARDRAIL 1\",\"{RunTime}\", \"{RequiredYesNo}\" )",
+        "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 1\", \"GUARDRAIL 1\"),\"{RunTime}\", \"{RequiredYesNo}\" )",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -596,7 +596,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data(\"GUARDRAIL 2\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "query": "gr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 2\", \"GUARDRAIL 2\"),\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 1,
         "title": "",
         "timeContext": {
@@ -766,7 +766,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data(\"GUARDRAIL 3\",\"{RunTime}\",  \"{RequiredYesNo}\")",
+        "query": "gr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 3\", \"GUARDRAIL 3\"),\"{RunTime}\",  \"{RequiredYesNo}\")",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -805,7 +805,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data(\"GUARDRAIL 4\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "query": "gr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 4\", \"GUARDRAIL 4\"),\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -844,7 +844,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data567(\"GUARDRAIL 5\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "query": "gr_data567(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 5\", \"GUARDRAIL 5\"),\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -881,7 +881,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data567(\"GUARDRAIL 6\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "query": "gr_data567(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 6\", \"GUARDRAIL 6\"),\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -911,7 +911,7 @@
       "conditionalVisibility": {
         "parameterName": "selectedTab",
         "comparison": "isEqualTo",
-        "value": "test6"
+        "value": "gr6"
       },
       "name": "query - 26 - Copy"
     },
@@ -919,7 +919,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data567(\"GUARDRAIL 7\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "query": "gr_data567(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 7\", \"GUARDRAIL 7\"),\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -956,7 +956,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 8\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['Subnet Name']=SubnetName_s, Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s,[\"ITSG Control\"]=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')\r\n| sort by Status asc",
+        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 8\", \"GUARDRAIL 8\");\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['Subnet Name']=SubnetName_s, Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s,[\"ITSG Control\"]=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')\r\n| sort by Status asc",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -993,7 +993,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 9\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['VNet Name']=column_ifexists('VNETName_s', ''), Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s, ['ITSG Control']=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')",
+        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 9\", \"GUARDRAIL 9\");\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['VNet Name']=column_ifexists('VNETName_s', ''), Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s, ['ITSG Control']=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -1038,7 +1038,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data(\"GUARDRAIL 10\",\"{RunTime}\", \"{RequiredYesNo}\")",
+        "query": "gr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 10\", \"GUARDRAIL 10\"),\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 4,
         "title": "",
         "timeContext": {
@@ -1077,7 +1077,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data11(\"GUARDRAIL 11\",\"{RunTime}\", \"{RequiredYesNo}\")",
+        "query": "gr_data11(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 11\", \"GUARDRAIL 11\"),\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 1,
         "title": "",
         "timeContext": {
@@ -1122,7 +1122,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data(\"GUARDRAIL 12\",\"{RunTime}\", \"{RequiredYesNo}\")",
+        "query": "gr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 12\", \"GUARDRAIL 12\"),\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 4,
         "title": "",
         "timeContext": {
@@ -1161,7 +1161,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(\"GUARDRAIL 13\",\"{RunTime}\", \"{RequiredYesNo}\" )",
+        "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 13\", \"GUARDRAIL 13\"),\"{RunTime}\", \"{RequiredYesNo}\" )",
         "size": 0,
         "title": "",
         "timeContext": {

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -1300,3 +1300,4 @@
     }
   ],
   "fallbackResourceIds": [
+

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -24,6 +24,28 @@
       "name": "parameters - initial locale"
     },
     {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "selectedTabLocale-param",
+            "version": "KqlParameterItem/1.0",
+            "name": "selectedTabLocale",
+            "type": 1,
+            "query": "print selectedTabLocale = strcat('{selectedTab}', '_', '{initialLocale}')",
+            "isHiddenWhenLocked": true,
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - selectedTabLocale"
+    },
+    {
       "type": 1,
       "content": {
         "json": "## Guardrails Accelerator\n\nSelect the Report Time and choose if Recommended Items are shown.\n\n(M) = Mandatory / (R) = Recommended",
@@ -509,9 +531,9 @@
       },
       "name": "Gr1-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr1"
+        "value": "gr1_en-CA"
       }
     },
     {
@@ -572,9 +594,9 @@
       },
       "name": "Gr1-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr1"
+        "value": "gr1_fr-CA"
       }
     },
     {
@@ -629,9 +651,9 @@
       },
       "name": "Gr2-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr2"
+        "value": "gr2_en-CA"
       }
     },
     {
@@ -693,9 +715,9 @@
       },
       "name": "Gr2-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr2"
+        "value": "gr2_fr-CA"
       }
     },
     {
@@ -815,9 +837,9 @@
       },
       "name": "Gr3-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr3"
+        "value": "gr3_en-CA"
       }
     },
     {
@@ -846,9 +868,9 @@
       },
       "name": "Gr3-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr3"
+        "value": "gr3_fr-CA"
       }
     },
     {
@@ -884,9 +906,9 @@
       },
       "name": "Gr4-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr4"
+        "value": "gr4_en-CA"
       }
     },
     {
@@ -915,9 +937,9 @@
       },
       "name": "Gr4-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr4"
+        "value": "gr4_fr-CA"
       }
     },
     {
@@ -951,9 +973,9 @@
       },
       "name": "Gr5-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr5"
+        "value": "gr5_en-CA"
       }
     },
     {
@@ -981,9 +1003,9 @@
       },
       "name": "Gr5-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr5"
+        "value": "gr5_fr-CA"
       }
     },
     {
@@ -1018,9 +1040,9 @@
       },
       "name": "Gr6-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr6"
+        "value": "gr6_en-CA"
       }
     },
     {
@@ -1049,9 +1071,9 @@
       },
       "name": "Gr6-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr6"
+        "value": "gr6_fr-CA"
       }
     },
     {
@@ -1085,9 +1107,9 @@
       },
       "name": "Gr7-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr7"
+        "value": "gr7_en-CA"
       }
     },
     {
@@ -1115,9 +1137,9 @@
       },
       "name": "Gr7-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr7"
+        "value": "gr7_fr-CA"
       }
     },
     {
@@ -1151,9 +1173,9 @@
       },
       "name": "Gr8-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr8"
+        "value": "gr8_en-CA"
       }
     },
     {
@@ -1187,9 +1209,9 @@
       },
       "name": "Gr8-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr8"
+        "value": "gr8_fr-CA"
       }
     },
     {
@@ -1231,9 +1253,9 @@
       },
       "name": "Gr9-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr9"
+        "value": "gr9_en-CA"
       }
     },
     {
@@ -1275,9 +1297,9 @@
       },
       "name": "Gr9-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr9"
+        "value": "gr9_fr-CA"
       }
     },
     {
@@ -1313,9 +1335,9 @@
       },
       "name": "Gr10-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr10"
+        "value": "gr10_en-CA"
       }
     },
     {
@@ -1344,9 +1366,9 @@
       },
       "name": "Gr10-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr10"
+        "value": "gr10_fr-CA"
       }
     },
     {
@@ -1388,9 +1410,9 @@
       },
       "name": "Gr11-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr11"
+        "value": "gr11_en-CA"
       }
     },
     {
@@ -1419,9 +1441,9 @@
       },
       "name": "Gr11-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr11"
+        "value": "gr11_fr-CA"
       }
     },
     {
@@ -1457,9 +1479,9 @@
       },
       "name": "Gr12-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr12"
+        "value": "gr12_en-CA"
       }
     },
     {
@@ -1488,9 +1510,9 @@
       },
       "name": "Gr12-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr12"
+        "value": "gr12_fr-CA"
       }
     },
     {
@@ -1526,9 +1548,9 @@
       },
       "name": "Gr13-English",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr13"
+        "value": "gr13_en-CA"
       }
     },
     {
@@ -1557,9 +1579,9 @@
       },
       "name": "Gr13-French",
       "conditionalVisibility": {
-        "parameterName": "selectedTab",
+        "parameterName": "selectedTabLocale",
         "comparison": "isEqualTo",
-        "value": "gr13"
+        "value": "gr13_fr-CA"
       }
     },
     {

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -64,15 +64,18 @@
             "isRequired": true,
             "query": "GuardrailsCompliance_CL\n| summarize by ReportTime_s \n| sort by ReportTime_s desc",
             "typeSettings": {
-              "additionalResourceOptions": [],
+              "additionalResourceOptions": [
+                "value::1"
+              ],
               "showDefault": false
             },
             "timeContext": {
               "durationMs": 86400000
             },
-            "defaultValue": "",
+            "defaultValue": "value::1",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "2023-01-16 19:55:14"
           }
         ],
         "style": "pills",
@@ -107,15 +110,18 @@
             "isRequired": true,
             "query": "GuardrailsCompliance_CL\n| summarize by ReportTime_s \n| sort by ReportTime_s desc",
             "typeSettings": {
-              "additionalResourceOptions": [],
+              "additionalResourceOptions": [
+                "value::1"
+              ],
               "showDefault": false
             },
             "timeContext": {
               "durationMs": 86400000
             },
-            "defaultValue": "",
+            "defaultValue": "value::1",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "2023-01-16 19:55:14"
           }
         ],
         "style": "pills",

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -7,6 +7,55 @@
         "version": "KqlParameterItem/1.0",
         "parameters": [
           {
+            "id": "initial-locale-param",
+            "version": "KqlParameterItem/1.0",
+            "name": "initialLocale",
+            "type": 1,
+            "isRequired": false,
+            "query": "GR_TenantInfo_CL | top 1 by TimeGenerated desc | project initialLocale = coalesce(locale_s, \"en-CA\")",
+            "isHiddenWhenLocked": true,
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - initial locale"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Guardrails Accelerator\n\nSelect the Report Time (Default is latest). Select whether Recommended items are shown.\n\n(M) = Mandatory / (R) = Recommended",
+        "style": "info"
+      },
+      "conditionalVisibility": {
+        "parameterName": "initialLocale",
+        "comparison": "isNotEqualTo",
+        "value": "fr-CA"
+      },
+      "name": "Details Title - English"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Accélérateur de barrières\n\nSélectionnez l'heure du rapport (par défaut, la plus récente). Sélectionnez si les éléments recommandés sont affichés.\n\n(M) = Obligatoire / (R) = Recommandé",
+        "style": "info"
+      },
+      "conditionalVisibility": {
+        "parameterName": "initialLocale",
+        "comparison": "isEqualTo",
+        "value": "fr-CA"
+      },
+      "name": "Details Title - French"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
             "id": "618c9321-a3de-4287-b4cf-860a4adf42d4",
             "version": "KqlParameterItem/1.0",
             "name": "RunTime",
@@ -40,7 +89,7 @@
           "value": "information"
         },
         {
-          "parameterName": "currentLocale",
+          "parameterName": "initialLocale",
           "comparison": "isNotEqualTo",
           "value": "fr-CA"
         }
@@ -86,7 +135,7 @@
           "value": "information"
         },
         {
-          "parameterName": "currentLocale",
+          "parameterName": "initialLocale",
           "comparison": "isEqualTo",
           "value": "fr-CA"
         }
@@ -117,32 +166,6 @@
       "name": "parameters - locale"
     },
     {
-      "type": 1,
-      "content": {
-        "json": "## Guardrails Accelerator\n\nSelect the Report Time (Default is latest). Select whether Recommended items are shown.\n\n(M) = Mandatory / (R) = Recommended",
-        "style": "info"
-      },
-      "conditionalVisibility": {
-        "parameterName": "currentLocale",
-        "comparison": "isNotEqualTo",
-        "value": "fr-CA"
-      },
-      "name": "Details Title - English"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "## Accélérateur de barrières\n\nSélectionnez l'heure du rapport (par défaut, la plus récente). Sélectionnez si les éléments recommandés sont affichés.\n\n(M) = Obligatoire / (R) = Recommandé",
-        "style": "info"
-      },
-      "conditionalVisibility": {
-        "parameterName": "currentLocale",
-        "comparison": "isEqualTo",
-        "value": "fr-CA"
-      },
-      "name": "Details Title - French"
-    },
-    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
@@ -170,7 +193,7 @@
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "conditionalVisibility": {
-        "parameterName": "currentLocale",
+        "parameterName": "initialLocale",
         "comparison": "isNotEqualTo",
         "value": "fr-CA"
       },
@@ -204,7 +227,7 @@
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "conditionalVisibility": {
-        "parameterName": "currentLocale",
+        "parameterName": "initialLocale",
         "comparison": "isEqualTo",
         "value": "fr-CA"
       },

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -1,14 +1,37 @@
 {
   "version": "Notebook/1.0",
   "items": [
+    // French Localization: Duplicate UI elements with conditional visibility based on locale
+    // English version shows when locale is NOT fr-CA
     {
       "type": 1,
       "content": {
         "json": "## Guardrails Accelerator\n\nSelect the Report Time (Default is latest). Select whether Recommended items are shown.\n\n(M) = Mandatory / (R) = Recommended",
         "style": "info"
       },
-      "name": "Details Title"
+      "conditionalVisibility": {
+        "parameterName": "currentLocale",
+        "comparison": "isNotEqualTo",
+        "value": "fr-CA"
+      },
+      "name": "Details Title - English"
     },
+    // French version shows when locale IS fr-CA
+    {
+      "type": 1,
+      "content": {
+        "json": "## Accélérateur de barrières\n\nSélectionnez l'heure du rapport (par défaut, la plus récente). Sélectionnez si les éléments recommandés sont affichés.\n\n(M) = Obligatoire / (R) = Recommandé",
+        "style": "info"
+      },
+      "conditionalVisibility": {
+        "parameterName": "currentLocale",
+        "comparison": "isEqualTo",
+        "value": "fr-CA"
+      },
+      "name": "Details Title - French"
+    },
+    // French Localization: Parameter sections are duplicated for English/French
+    // English parameter UI - shows when locale is not fr-CA
     {
       "type": 9,
       "content": {
@@ -36,8 +59,52 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "name": "parameters - 19"
+      "conditionalVisibility": {
+        "parameterName": "currentLocale",
+        "comparison": "isNotEqualTo",
+        "value": "fr-CA"
+      },
+      "name": "parameters - 19 - English"
     },
+    // French parameter UI - shows when locale is fr-CA
+    // Note: jsonData contains French labels (Oui/Non instead of Yes/No)
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "c90ebce2-9568-40ee-82cd-a8fd774f2e6b",
+            "version": "KqlParameterItem/1.0",
+            "name": "RequiredYesNo",
+            "label": "Afficher les contrôles recommandés",
+            "type": 10,
+            "isRequired": true,
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "jsonData": "[\n    { \"value\":\"Other\", \"label\":\"Oui\" },\n    { \"value\":\"False\", \"label\":\"Non\", \"selected\":true }\n]",
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "value": "Other"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "currentLocale",
+        "comparison": "isEqualTo",
+        "value": "fr-CA"
+      },
+      "name": "parameters - 19 - French"
+    },
+    // French Localization: Second parameter section - English version
+    // Workbook has multiple parameter sections - each needs its own locale parameter
+    // Shows when locale is not fr-CA
     {
       "type": 9,
       "content": {
@@ -47,7 +114,7 @@
             "id": "618c9321-a3de-4287-b4cf-860a4adf42d4",
             "version": "KqlParameterItem/1.0",
             "name": "RunTime",
-            "label": "Report Time",
+            "label": "Report Time (UTC)",
             "type": 2,
             "isRequired": true,
             "query": "GuardrailsCompliance_CL\n| summarize by ReportTime_s \n| sort by ReportTime_s desc",
@@ -64,19 +131,119 @@
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "2023-01-16 19:55:14"
+          },
+          // French Localization: Hidden parameter that reads locale from Log Analytics
+          // Gets locale stored by PowerShell modules, defaults to en-CA if not found
+          // This drives all conditional visibility throughout the workbook
+          {
+            "id": "locale-param",
+            "version": "KqlParameterItem/1.0",
+            "name": "currentLocale",
+            "type": 1,
+            "isRequired": false,
+            "query": "GR_TenantInfo_CL | where ReportTime_s == \"{RunTime}\" | top 1 by TimeGenerated desc | project coalesce(locale_s, \"en-CA\")",
+            "isHiddenWhenLocked": true,
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "pills",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isNotEqualTo",
-        "value": "information"
-      },
-      "name": "parameters - 1"
+      // French Localization: Multiple conditions for visibility (ALL must be true)
+      // 1. selectedTab != "information" - Hide when Information tab is selected
+      // 2. currentLocale != "fr-CA" - Show English version when locale is not French
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isNotEqualTo",
+          "value": "information"
+        },
+        {
+          "parameterName": "currentLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "parameters - 1 - English"
     },
+    // French Localization: Second parameter section - French version
+    // This duplicates the RunTime parameter with French labels
+    // Shows when locale is fr-CA
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "618c9321-a3de-4287-b4cf-860a4adf42d4",
+            "version": "KqlParameterItem/1.0",
+            "name": "RunTime",
+            "label": "Heure du rapport (UTC)",
+            "type": 2,
+            "isRequired": true,
+            "query": "GuardrailsCompliance_CL\n| summarize by ReportTime_s \n| sort by ReportTime_s desc",
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1"
+              ],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "defaultValue": "value::1",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "2023-01-16 19:55:14"
+          },
+          // French Localization: DUPLICATE locale parameter (required)
+          // Must be repeated in each parameter section due to Azure Workbook scope limitations
+          // Parameters from one section aren't accessible to other sections
+          // This enables conditional visibility to work throughout the entire workbook
+          {
+            "id": "locale-param",
+            "version": "KqlParameterItem/1.0",
+            "name": "currentLocale",
+            "type": 1,
+            "isRequired": false,
+            "query": "GR_TenantInfo_CL | where ReportTime_s == \"{RunTime}\" | top 1 by TimeGenerated desc | project coalesce(locale_s, \"en-CA\")",
+            "isHiddenWhenLocked": true,
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      // French Localization: Multiple conditions for visibility (ALL must be true)
+      // 1. selectedTab != "information" - Hide when Information tab is selected
+      // 2. currentLocale == "fr-CA" - Show French version when locale is French
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isNotEqualTo",
+          "value": "information"
+        },
+        {
+          "parameterName": "currentLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "parameters - 1 - French"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n### IMPORTANT: Localization Pattern\nThe following tab sections are DUPLICATED for English/French localization.\n- **English tabs**: Visible when locale != 'fr-CA'\n- **French tabs**: Visible when locale == 'fr-CA'\n\n⚠️ **WARNING**: When adding/modifying tabs, you MUST update BOTH sections to keep them in sync!\n---"
+      },
+      "name": "localization-warning"
+    },
+    // French Localization: English tab navigation
+    // Shows when locale is not fr-CA
     {
       "type": 11,
       "content": {
@@ -197,7 +364,141 @@
           }
         ]
       },
-      "name": "links - 1"
+      "conditionalVisibility": {
+        "parameterName": "currentLocale",
+        "comparison": "isNotEqualTo",
+        "value": "fr-CA"
+      },
+      "name": "links - 1 - English"
+    },
+    // French Localization: Tab labels translated to French
+    // Shows BARRIÈRE instead of GUARDRAIL when locale is fr-CA
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "id": "6a683959-7ed3-42b1-a509-3cdcd18017cf",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 1",
+            "subTarget": "gr1",
+            "style": "link"
+          },
+          {
+            "id": "6a683959-7fd3-42b1-a509-3cdcd18017cf",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 2",
+            "subTarget": "gr2",
+            "style": "link"
+          },
+          {
+            "id": "6a683359-5ed3-42b1-a509-3cdcd18017cf",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 3",
+            "subTarget": "gr3",
+            "style": "link"
+          },
+          {
+            "id": "6a383959-1ed3-42b1-a509-3cdcd18017cf",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 4",
+            "subTarget": "gr4",
+            "style": "link"
+          },
+          {
+            "id": "6b683959-7ed3-42b1-a509-3cdcd18017cf",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 5",
+            "subTarget": "gr5",
+            "style": "link"
+          },
+          {
+            "id": "6a683959-4fd3-42b1-a509-3cdcd18017cf",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 6",
+            "subTarget": "test6",
+            "style": "link"
+          },
+          {
+            "id": "6a683959-7ed3-42b1-a509-3cfcd18017cf",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 7",
+            "subTarget": "gr7",
+            "style": "link"
+          },
+          {
+            "id": "4b2de2e9-a9c7-486c-a524-7da0e8f44d26",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 8",
+            "subTarget": "gr8",
+            "style": "link"
+          },
+          {
+            "id": "40243b3d-3037-482b-959b-d95c1b4b2014",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 9",
+            "subTarget": "gr9",
+            "style": "link"
+          },
+          {
+            "id": "6bc4aa50-56c1-425b-9894-d6d7edb20e3a",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 10",
+            "subTarget": "gr10",
+            "style": "link"
+          },
+          {
+            "id": "cad591d5-9404-46e2-b56f-b32723b390de",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 11",
+            "subTarget": "gr11",
+            "style": "link"
+          },
+          {
+            "id": "144c0d71-a9de-4e02-95bf-0474d243ada6",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 12",
+            "subTarget": "gr12",
+            "style": "link"
+          },
+          {
+            "id": "6a683959-2ed3-42b1-a509-3cdcd18017cf",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "BARRIÈRE 13",
+            "subTarget": "gr13",
+            "style": "link"
+          },
+          {
+            "id": "8c5914bd-a497-473f-b767-f646b642fe5e",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Informations",
+            "subTarget": "information",
+            "style": "link"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "currentLocale",
+        "comparison": "isEqualTo",
+        "value": "fr-CA"
+      },
+      "name": "links - 1 - French"
     },
     {
       "type": 3,

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -500,7 +500,7 @@
         "version": "KqlItem/1.0",
         "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(\"GUARDRAIL 1\",\"{RunTime}\", \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "GR 1",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -598,7 +598,7 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"GUARDRAIL 2\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 1,
-        "title": "GR 2",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -768,7 +768,7 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"GUARDRAIL 3\",\"{RunTime}\",  \"{RequiredYesNo}\")",
         "size": 0,
-        "title": "GR 3",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -807,7 +807,7 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"GUARDRAIL 4\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "GR 4",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -846,7 +846,7 @@
         "version": "KqlItem/1.0",
         "query": "gr_data567(\"GUARDRAIL 5\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "GR 5",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -883,7 +883,7 @@
         "version": "KqlItem/1.0",
         "query": "gr_data567(\"GUARDRAIL 6\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "GR 6",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -921,7 +921,7 @@
         "version": "KqlItem/1.0",
         "query": "gr_data567(\"GUARDRAIL 7\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "GR 7",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -958,7 +958,7 @@
         "version": "KqlItem/1.0",
         "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 8\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['Subnet Name']=SubnetName_s, Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s,[\"ITSG Control\"]=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')\r\n| sort by Status asc",
         "size": 0,
-        "title": "GR 8",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -995,7 +995,7 @@
         "version": "KqlItem/1.0",
         "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 9\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['VNet Name']=column_ifexists('VNETName_s', ''), Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s, ['ITSG Control']=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')",
         "size": 0,
-        "title": "GR 9",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1040,7 +1040,7 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"GUARDRAIL 10\",\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 4,
-        "title": "GR 10",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1079,7 +1079,7 @@
         "version": "KqlItem/1.0",
         "query": "gr_data11(\"GUARDRAIL 11\",\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 1,
-        "title": "GR 11",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1124,7 +1124,7 @@
         "version": "KqlItem/1.0",
         "query": "gr_data(\"GUARDRAIL 12\",\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 4,
-        "title": "GR 12",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },
@@ -1163,7 +1163,7 @@
         "version": "KqlItem/1.0",
         "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(\"GUARDRAIL 13\",\"{RunTime}\", \"{RequiredYesNo}\" )",
         "size": 0,
-        "title": "GR 13",
+        "title": "",
         "timeContext": {
           "durationMs": 86400000
         },

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -27,7 +27,7 @@
     {
       "type": 1,
       "content": {
-        "json": "## Guardrails Accelerator\n\nSelect the Report Time (Default is latest). Select if Recommended items are shown.\n\n(M) = Mandatory / (R) = Recommended",
+        "json": "## Guardrails Accelerator\n\nSelect the Report Time and choose if Recommended Items are shown.\n\n(M) = Mandatory / (R) = Recommended",
         "style": "info"
       },
       "conditionalVisibility": {

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -70,7 +70,6 @@
             "timeContext": {
               "durationMs": 86400000
             },
-            "defaultValue": "value::1",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "2023-01-16 19:55:14"
@@ -114,7 +113,6 @@
             "timeContext": {
               "durationMs": 86400000
             },
-            "defaultValue": "value::1",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "2023-01-16 19:55:14"

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -27,7 +27,7 @@
     {
       "type": 1,
       "content": {
-        "json": "## Guardrails Accelerator\n\nSelect the Report Time (Default is latest). Select whether Recommended items are shown.\n\n(M) = Mandatory / (R) = Recommended",
+        "json": "## Guardrails Accelerator\n\nSelect the Report Time (Default is latest). Select if Recommended items are shown.\n\n(M) = Mandatory / (R) = Recommended",
         "style": "info"
       },
       "conditionalVisibility": {
@@ -40,7 +40,7 @@
     {
       "type": 1,
       "content": {
-        "json": "## Accélérateur de barrières\n\nSélectionnez l'heure du rapport (par défaut, la plus récente). Sélectionnez si les éléments recommandés sont affichés.\n\n(M) = Obligatoire / (R) = Recommandé",
+        "json": "## Accélérateur de mesures de protection\n\nSélectionnez l'heure du rapport et choisissez si les articles recommandés sont affichés.\n\n(M) = Obligatoire / (R) = Recommandé",
         "style": "info"
       },
       "conditionalVisibility": {
@@ -377,7 +377,7 @@
             "id": "6a683959-7ed3-42b1-a509-3cdcd18017cf",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 1",
+            "linkLabel": "MESURE 1",
             "subTarget": "gr1",
             "style": "link"
           },
@@ -385,7 +385,7 @@
             "id": "6a683959-7fd3-42b1-a509-3cdcd18017cf",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 2",
+            "linkLabel": "MESURE 2",
             "subTarget": "gr2",
             "style": "link"
           },
@@ -393,7 +393,7 @@
             "id": "6a683359-5ed3-42b1-a509-3cdcd18017cf",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 3",
+            "linkLabel": "MESURE 3",
             "subTarget": "gr3",
             "style": "link"
           },
@@ -401,7 +401,7 @@
             "id": "6a383959-1ed3-42b1-a509-3cdcd18017cf",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 4",
+            "linkLabel": "MESURE 4",
             "subTarget": "gr4",
             "style": "link"
           },
@@ -409,7 +409,7 @@
             "id": "6b683959-7ed3-42b1-a509-3cdcd18017cf",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 5",
+            "linkLabel": "MESURE 5",
             "subTarget": "gr5",
             "style": "link"
           },
@@ -417,7 +417,7 @@
             "id": "6a683959-4fd3-42b1-a509-3cdcd18017cf",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 6",
+            "linkLabel": "MESURE 6",
             "subTarget": "test6",
             "style": "link"
           },
@@ -425,7 +425,7 @@
             "id": "6a683959-7ed3-42b1-a509-3cfcd18017cf",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 7",
+            "linkLabel": "MESURE 7",
             "subTarget": "gr7",
             "style": "link"
           },
@@ -433,7 +433,7 @@
             "id": "4b2de2e9-a9c7-486c-a524-7da0e8f44d26",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 8",
+            "linkLabel": "MESURE 8",
             "subTarget": "gr8",
             "style": "link"
           },
@@ -441,7 +441,7 @@
             "id": "40243b3d-3037-482b-959b-d95c1b4b2014",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 9",
+            "linkLabel": "MESURE 9",
             "subTarget": "gr9",
             "style": "link"
           },
@@ -449,7 +449,7 @@
             "id": "6bc4aa50-56c1-425b-9894-d6d7edb20e3a",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 10",
+            "linkLabel": "MESURE 10",
             "subTarget": "gr10",
             "style": "link"
           },
@@ -457,7 +457,7 @@
             "id": "cad591d5-9404-46e2-b56f-b32723b390de",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 11",
+            "linkLabel": "MESURE 11",
             "subTarget": "gr11",
             "style": "link"
           },
@@ -465,7 +465,7 @@
             "id": "144c0d71-a9de-4e02-95bf-0474d243ada6",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 12",
+            "linkLabel": "MESURE 12",
             "subTarget": "gr12",
             "style": "link"
           },
@@ -473,7 +473,7 @@
             "id": "6a683959-2ed3-42b1-a509-3cdcd18017cf",
             "cellValue": "selectedTab",
             "linkTarget": "parameter",
-            "linkLabel": "BARRIÈRE 13",
+            "linkLabel": "MESURE 13",
             "subTarget": "gr13",
             "style": "link"
           },

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -24,28 +24,6 @@
       "name": "parameters - initial locale"
     },
     {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "selectedTabLocale-param",
-            "version": "KqlParameterItem/1.0",
-            "name": "selectedTabLocale",
-            "type": 1,
-            "query": "print selectedTabLocale = strcat('{selectedTab}', '_', '{initialLocale}')",
-            "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          }
-        ],
-        "style": "pills",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "name": "parameters - selectedTabLocale"
-    },
-    {
       "type": 1,
       "content": {
         "json": "## Guardrails Accelerator\n\nSelect the Report Time and choose if Recommended Items are shown.\n\n(M) = Mandatory / (R) = Recommended",
@@ -530,11 +508,18 @@
         }
       },
       "name": "Gr1-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr1_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr1"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 9,
@@ -593,11 +578,18 @@
         }
       },
       "name": "Gr1-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr1_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr1"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -650,11 +642,18 @@
         }
       },
       "name": "Gr2-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr2_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr2"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 9,
@@ -714,11 +713,18 @@
         }
       },
       "name": "Gr2-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr2_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr2"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -836,11 +842,18 @@
         }
       },
       "name": "Gr3-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr3_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr3"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -867,11 +880,18 @@
         }
       },
       "name": "Gr3-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr3_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr3"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -905,11 +925,18 @@
         }
       },
       "name": "Gr4-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr4_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr4"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -936,11 +963,18 @@
         }
       },
       "name": "Gr4-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr4_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr4"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -972,11 +1006,18 @@
         }
       },
       "name": "Gr5-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr5_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr5"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1002,11 +1043,18 @@
         }
       },
       "name": "Gr5-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr5_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr5"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1039,11 +1087,18 @@
         }
       },
       "name": "Gr6-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr6_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr6"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1070,11 +1125,18 @@
         }
       },
       "name": "Gr6-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr6_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr6"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1106,11 +1168,18 @@
         }
       },
       "name": "Gr7-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr7_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr7"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1136,11 +1205,18 @@
         }
       },
       "name": "Gr7-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr7_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr7"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1172,11 +1248,18 @@
         }
       },
       "name": "Gr8-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr8_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr8"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1208,11 +1291,18 @@
         }
       },
       "name": "Gr8-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr8_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr8"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1252,11 +1342,18 @@
         }
       },
       "name": "Gr9-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr9_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr9"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1296,11 +1393,18 @@
         }
       },
       "name": "Gr9-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr9_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr9"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1334,11 +1438,18 @@
         }
       },
       "name": "Gr10-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr10_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr10"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1365,11 +1476,18 @@
         }
       },
       "name": "Gr10-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr10_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr10"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1409,11 +1527,18 @@
         }
       },
       "name": "Gr11-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr11_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr11"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1440,11 +1565,18 @@
         }
       },
       "name": "Gr11-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr11_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr11"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1478,11 +1610,18 @@
         }
       },
       "name": "Gr12-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr12_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr12"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1509,11 +1648,18 @@
         }
       },
       "name": "Gr12-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr12_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr12"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1547,11 +1693,18 @@
         }
       },
       "name": "Gr13-English",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr13_en-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr13"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,
@@ -1578,11 +1731,18 @@
         }
       },
       "name": "Gr13-French",
-      "conditionalVisibility": {
-        "parameterName": "selectedTabLocale",
-        "comparison": "isEqualTo",
-        "value": "gr13_fr-CA"
-      }
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr13"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ]
     },
     {
       "type": 3,

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -128,7 +128,7 @@
             "name": "currentLocale",
             "type": 1,
             "isRequired": false,
-            "query": "GR_TenantInfo_CL | where ReportTime_s == \"{RunTime}\" | top 1 by TimeGenerated desc | project coalesce(locale_s, \"en-CA\")",
+            "query": "GR_TenantInfo_CL | where ReportTime_s == \"{RunTime}\" | top 1 by TimeGenerated desc | project currentLocale = coalesce(locale_s, \"en-CA\")",
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -185,7 +185,7 @@
             "name": "currentLocale",
             "type": 1,
             "isRequired": false,
-            "query": "GR_TenantInfo_CL | where ReportTime_s == \"{RunTime}\" | top 1 by TimeGenerated desc | project coalesce(locale_s, \"en-CA\")",
+            "query": "GR_TenantInfo_CL | where ReportTime_s == \"{RunTime}\" | top 1 by TimeGenerated desc | project currentLocale = coalesce(locale_s, \"en-CA\")",
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -208,13 +208,6 @@
         }
       ],
       "name": "parameters - 1 - French"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "---\n### IMPORTANT: Localization Pattern\nThe following tab sections are DUPLICATED for English/French localization.\n- **English tabs**: Visible when locale != 'fr-CA'\n- **French tabs**: Visible when locale == 'fr-CA'\n\n⚠️ **WARNING**: When adding/modifying tabs, you MUST update BOTH sections to keep them in sync!\n---"
-      },
-      "name": "localization-warning"
     },
     {
       "type": 11,
@@ -1306,4 +1299,3 @@
     }
   ],
   "fallbackResourceIds": [
-

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -2,6 +2,121 @@
   "version": "Notebook/1.0",
   "items": [
     {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "618c9321-a3de-4287-b4cf-860a4adf42d4",
+            "version": "KqlParameterItem/1.0",
+            "name": "RunTime",
+            "label": "Report Time (UTC)",
+            "type": 2,
+            "isRequired": true,
+            "query": "GuardrailsCompliance_CL\n| summarize by ReportTime_s \n| sort by ReportTime_s desc",
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1"
+              ],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "defaultValue": "value::1",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "2023-01-16 19:55:14"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isNotEqualTo",
+          "value": "information"
+        },
+        {
+          "parameterName": "currentLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "parameters - 1 - English"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "618c9321-a3de-4287-b4cf-860a4adf42d4",
+            "version": "KqlParameterItem/1.0",
+            "name": "RunTime",
+            "label": "Heure du rapport (UTC)",
+            "type": 2,
+            "isRequired": true,
+            "query": "GuardrailsCompliance_CL\n| summarize by ReportTime_s \n| sort by ReportTime_s desc",
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1"
+              ],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "defaultValue": "value::1",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "2023-01-16 19:55:14"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isNotEqualTo",
+          "value": "information"
+        },
+        {
+          "parameterName": "currentLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "parameters - 1 - French"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "locale-param-single",
+            "version": "KqlParameterItem/1.0",
+            "name": "currentLocale",
+            "type": 1,
+            "isRequired": false,
+            "query": "GR_TenantInfo_CL | where ReportTime_s == \"{RunTime}\" | top 1 by TimeGenerated desc | project currentLocale = coalesce(locale_s, \"en-CA\")",
+            "isHiddenWhenLocked": true,
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - locale"
+    },
+    {
       "type": 1,
       "content": {
         "json": "## Guardrails Accelerator\n\nSelect the Report Time (Default is latest). Select whether Recommended items are shown.\n\n(M) = Mandatory / (R) = Recommended",
@@ -94,120 +209,6 @@
         "value": "fr-CA"
       },
       "name": "parameters - 19 - French"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "618c9321-a3de-4287-b4cf-860a4adf42d4",
-            "version": "KqlParameterItem/1.0",
-            "name": "RunTime",
-            "label": "Report Time (UTC)",
-            "type": 2,
-            "isRequired": true,
-            "query": "GuardrailsCompliance_CL\n| summarize by ReportTime_s \n| sort by ReportTime_s desc",
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ],
-              "showDefault": false
-            },
-            "timeContext": {
-              "durationMs": 86400000
-            },
-            "defaultValue": "value::1",
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "2023-01-16 19:55:14"
-          },
-          {
-            "id": "locale-param",
-            "version": "KqlParameterItem/1.0",
-            "name": "currentLocale",
-            "type": 1,
-            "isRequired": false,
-            "query": "GR_TenantInfo_CL | where ReportTime_s == \"{RunTime}\" | top 1 by TimeGenerated desc | project currentLocale = coalesce(locale_s, \"en-CA\")",
-            "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          }
-        ],
-        "style": "pills",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isNotEqualTo",
-          "value": "information"
-        },
-        {
-          "parameterName": "currentLocale",
-          "comparison": "isNotEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "parameters - 1 - English"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "618c9321-a3de-4287-b4cf-860a4adf42d4",
-            "version": "KqlParameterItem/1.0",
-            "name": "RunTime",
-            "label": "Heure du rapport (UTC)",
-            "type": 2,
-            "isRequired": true,
-            "query": "GuardrailsCompliance_CL\n| summarize by ReportTime_s \n| sort by ReportTime_s desc",
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ],
-              "showDefault": false
-            },
-            "timeContext": {
-              "durationMs": 86400000
-            },
-            "defaultValue": "value::1",
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "2023-01-16 19:55:14"
-          },
-          {
-            "id": "locale-param",
-            "version": "KqlParameterItem/1.0",
-            "name": "currentLocale",
-            "type": 1,
-            "isRequired": false,
-            "query": "GR_TenantInfo_CL | where ReportTime_s == \"{RunTime}\" | top 1 by TimeGenerated desc | project currentLocale = coalesce(locale_s, \"en-CA\")",
-            "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          }
-        ],
-        "style": "pills",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "selectedTab",
-          "comparison": "isNotEqualTo",
-          "value": "information"
-        },
-        {
-          "parameterName": "currentLocale",
-          "comparison": "isEqualTo",
-          "value": "fr-CA"
-        }
-      ],
-      "name": "parameters - 1 - French"
     },
     {
       "type": 11,
@@ -1299,3 +1300,7 @@
     }
   ],
   "fallbackResourceIds": [
+    "/subscriptions/{Subscription}/resourceGroups/{ResourceGroup}/providers/Microsoft.OperationalInsights/workspaces/{Workspace}"
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -194,7 +194,7 @@
             "value": "Other"
           }
         ],
-        "style": "above",
+        "style": "pills",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
@@ -229,7 +229,7 @@
             "value": "Other"
           }
         ],
-        "style": "above",
+        "style": "pills",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -64,9 +64,7 @@
             "isRequired": true,
             "query": "GuardrailsCompliance_CL\n| summarize by ReportTime_s \n| sort by ReportTime_s desc",
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ],
+              "additionalResourceOptions": [],
               "showDefault": false
             },
             "timeContext": {
@@ -110,9 +108,7 @@
             "isRequired": true,
             "query": "GuardrailsCompliance_CL\n| summarize by ReportTime_s \n| sort by ReportTime_s desc",
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ],
+              "additionalResourceOptions": [],
               "showDefault": false
             },
             "timeContext": {

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -498,7 +498,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 1\", \"GUARDRAIL 1\"),\"{RunTime}\", \"{RequiredYesNo}\" )",
+        "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(\"GUARDRAIL 1\",\"{RunTime}\", \"{RequiredYesNo}\" )",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -526,12 +526,19 @@
           ]
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr1"
-      },
-      "name": "Gr1"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr1"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr1-English"
     },
     {
       "type": 9,
@@ -570,6 +577,45 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
+        "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(\"MESURE DE PROTECTION 1\",\"{RunTime}\", \"{RequiredYesNo}\" )",
+        "size": 0,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "URL",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr1"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr1-French"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
         "query": "GR1NonMfaUsers_CL \n| where ReportTime_s == \"{RunTime}\"\n| extend \n    CreatedRaw = coalesce(\n        column_ifexists(\"CreatedTime_t\", datetime(null)), \n        todatetime(column_ifexists(\"CreatedTime_s\", \"\"))\n    ),\n    LastSignInRaw = coalesce(\n        column_ifexists(\"LastSignIn_t\", datetime(null)), \n        todatetime(column_ifexists(\"LastSignIn_s\", \"\"))\n    )\n| extend \n    CreatedTime = iff(isnull(CreatedRaw), \"N/A\", format_datetime(CreatedRaw, 'yyyy-MM-dd HH:mm:ss')),\n    LastSignIn = iff(isnull(LastSignInRaw), \"Never Signed In\", format_datetime(LastSignInRaw, 'yyyy-MM-dd HH:mm:ss'))\n| project DisplayName_s, UserPrincipalName_s, User_Type_s, CreatedTime, LastSignIn, Comments_s\n",
         "size": 0,
         "timeContext": {
@@ -596,7 +642,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 2\", \"GUARDRAIL 2\"),\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "query": "gr_data(\"GUARDRAIL 2\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 1,
         "title": "",
         "timeContext": {
@@ -624,12 +670,19 @@
           ]
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr2"
-      },
-      "name": "Gr1 - Copy"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr2"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr2-English"
     },
     {
       "type": 9,
@@ -663,6 +716,45 @@
         "value": "gr2"
       },
       "name": "parameters - 18"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "gr_data(\"MESURE DE PROTECTION 2\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "size": 1,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "URL",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr2"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr2-French"
     },
     {
       "type": 3,
@@ -794,18 +886,64 @@
           ]
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr3"
-      },
-      "name": "Gr1 - Copy - Copy"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr3"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr3-English"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 4\", \"GUARDRAIL 4\"),\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "query": "gr_data(\"MESURE DE PROTECTION 3\",\"{RunTime}\",  \"{RequiredYesNo}\")",
+        "size": 0,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "URL",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr3"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr3-French"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "gr_data(\"GUARDRAIL 4\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -833,18 +971,64 @@
           ]
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr4"
-      },
-      "name": "query - 6 - Copy"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr4"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr4-English"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data567(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 5\", \"GUARDRAIL 5\"),\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "query": "gr_data(\"MESURE DE PROTECTION 4\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "size": 0,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "URL",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr4"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr4-French"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "gr_data567(\"GUARDRAIL 5\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -870,18 +1054,63 @@
           }
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr5"
-      },
-      "name": "query - 2 - Copy - Copy"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr5"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr5-English"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data567(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 6\", \"GUARDRAIL 6\"),\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "query": "gr_data567(\"MESURE DE PROTECTION 5\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "size": 0,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "URL",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr5"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr5-French"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "gr_data567(\"GUARDRAIL 6\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -908,18 +1137,64 @@
           }
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr6"
-      },
-      "name": "query - 26 - Copy"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr6"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr6-English"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data567(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 7\", \"GUARDRAIL 7\"),\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "query": "gr_data567(\"MESURE DE PROTECTION 6\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "size": 0,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "exportToExcelOptions": "all",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "URL",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr6"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr6-French"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "gr_data567(\"GUARDRAIL 7\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -945,18 +1220,63 @@
           }
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr7"
-      },
-      "name": "query - 6 - Copy"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr7"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr7-English"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 8\", \"GUARDRAIL 8\");\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['Subnet Name']=SubnetName_s, Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s,[\"ITSG Control\"]=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')\r\n| sort by Status asc",
+        "query": "gr_data567(\"MESURE DE PROTECTION 7\",\"{RunTime}\",  \"{RequiredYesNo}\" )",
+        "size": 0,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "URL",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr7"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr7-French"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 8\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['Subnet Name']=SubnetName_s, Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s,[\"ITSG Control\"]=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')\r\n| sort by Status asc",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -982,18 +1302,69 @@
           }
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr8"
-      },
-      "name": "query - 2"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr8"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr8-English"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 9\", \"GUARDRAIL 9\");\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['VNet Name']=column_ifexists('VNETName_s', ''), Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s, ['ITSG Control']=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')",
+        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"MESURE DE PROTECTION 8\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['Subnet Name']=SubnetName_s, Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s,[\"ITSG Control\"]=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')\r\n| sort by Status asc",
+        "size": 0,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Remediation",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ],
+          "hierarchySettings": {
+            "treeType": 1,
+            "groupBy": [
+              "Status"
+            ]
+          }
+        }
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr8"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr8-French"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 9\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['VNet Name']=column_ifexists('VNETName_s', ''), Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s, ['ITSG Control']=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -1027,18 +1398,77 @@
           }
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr9"
-      },
-      "name": "query - 3"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr9"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr9-English"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 10\", \"GUARDRAIL 10\"),\"{RunTime}\", \"{RequiredYesNo}\")",
+        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"MESURE DE PROTECTION 9\";\r\nGuardrailsCompliance_CL\r\n| where ControlName_s has ctrlprefix  and ReportTime_s == \"{RunTime}\" and Required_s !=tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ['Item Name']=ItemName_s, ['Subscription Name']=SubscriptionName_s, ['VNet Name']=column_ifexists('VNETName_s', ''), Status=case(ComplianceStatus_b == true, \"✔️\", ComplianceStatus_b == false, \"❌\", \"➖\"), Comments=Comments_s, ['ITSG Control']=itsgcode_s, Remediation=gr_geturl(replace_string(ctrlprefix,\" \",\"\"),itsgcode_s), Profile=iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')",
+        "size": 0,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Remediation",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            },
+            {
+              "columnMatch": "Link",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ],
+          "hierarchySettings": {
+            "treeType": 1,
+            "groupBy": [
+              "Status"
+            ]
+          }
+        }
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr9"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr9-French"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "gr_data(\"GUARDRAIL 10\",\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 4,
         "title": "",
         "timeContext": {
@@ -1066,18 +1496,64 @@
           ]
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr10"
-      },
-      "name": "query - 2 - Copy - Copy - Copy"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr10"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr10-English"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data11(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 11\", \"GUARDRAIL 11\"),\"{RunTime}\", \"{RequiredYesNo}\")",
+        "query": "gr_data(\"MESURE DE PROTECTION 10\",\"{RunTime}\", \"{RequiredYesNo}\")",
+        "size": 4,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "URL",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr10"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr10-French"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "gr_data11(\"GUARDRAIL 11\",\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 1,
         "title": "",
         "timeContext": {
@@ -1111,18 +1587,64 @@
           }
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr11"
-      },
-      "name": "query - 2 - Copy - Copy - Copy - Copy"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr11"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr11-English"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 12\", \"GUARDRAIL 12\"),\"{RunTime}\", \"{RequiredYesNo}\")",
+        "query": "gr_data11(\"MESURE DE PROTECTION 11\",\"{RunTime}\", \"{RequiredYesNo}\")",
+        "size": 1,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "URL",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr11"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr11-French"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "gr_data(\"GUARDRAIL 12\",\"{RunTime}\", \"{RequiredYesNo}\")",
         "size": 4,
         "title": "",
         "timeContext": {
@@ -1150,18 +1672,64 @@
           ]
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr12"
-      },
-      "name": "GR11"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr12"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr12-English"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(iff(\"{initialLocale}\" == \"fr-CA\", \"MESURE DE PROTECTION 13\", \"GUARDRAIL 13\"),\"{RunTime}\", \"{RequiredYesNo}\" )",
+        "query": "gr_data(\"MESURE DE PROTECTION 12\",\"{RunTime}\", \"{RequiredYesNo}\")",
+        "size": 4,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "URL",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr12"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr12-French"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(\"GUARDRAIL 13\",\"{RunTime}\", \"{RequiredYesNo}\" )",
         "size": 0,
         "title": "",
         "timeContext": {
@@ -1189,12 +1757,58 @@
           ]
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "gr13"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr13"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isNotEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr13-English"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "//let lic = GRITSGControls_CL | summarize max(TimeGenerated);\r\ngr_data(\"MESURE DE PROTECTION 13\",\"{RunTime}\", \"{RequiredYesNo}\" )",
+        "size": 0,
+        "title": "",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "URL",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "Url"
+              }
+            }
+          ]
+        }
       },
-      "name": "Gr13"
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "gr13"
+        },
+        {
+          "parameterName": "initialLocale",
+          "comparison": "isEqualTo",
+          "value": "fr-CA"
+        }
+      ],
+      "name": "Gr13-French"
     },
     {
       "type": 3,

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -1,8 +1,6 @@
 {
   "version": "Notebook/1.0",
   "items": [
-    // French Localization: Duplicate UI elements with conditional visibility based on locale
-    // English version shows when locale is NOT fr-CA
     {
       "type": 1,
       "content": {
@@ -16,7 +14,6 @@
       },
       "name": "Details Title - English"
     },
-    // French version shows when locale IS fr-CA
     {
       "type": 1,
       "content": {
@@ -30,8 +27,6 @@
       },
       "name": "Details Title - French"
     },
-    // French Localization: Parameter sections are duplicated for English/French
-    // English parameter UI - shows when locale is not fr-CA
     {
       "type": 9,
       "content": {
@@ -66,8 +61,6 @@
       },
       "name": "parameters - 19 - English"
     },
-    // French parameter UI - shows when locale is fr-CA
-    // Note: jsonData contains French labels (Oui/Non instead of Yes/No)
     {
       "type": 9,
       "content": {
@@ -102,9 +95,6 @@
       },
       "name": "parameters - 19 - French"
     },
-    // French Localization: Second parameter section - English version
-    // Workbook has multiple parameter sections - each needs its own locale parameter
-    // Shows when locale is not fr-CA
     {
       "type": 9,
       "content": {
@@ -132,9 +122,6 @@
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "2023-01-16 19:55:14"
           },
-          // French Localization: Hidden parameter that reads locale from Log Analytics
-          // Gets locale stored by PowerShell modules, defaults to en-CA if not found
-          // This drives all conditional visibility throughout the workbook
           {
             "id": "locale-param",
             "version": "KqlParameterItem/1.0",
@@ -151,9 +138,6 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      // French Localization: Multiple conditions for visibility (ALL must be true)
-      // 1. selectedTab != "information" - Hide when Information tab is selected
-      // 2. currentLocale != "fr-CA" - Show English version when locale is not French
       "conditionalVisibilities": [
         {
           "parameterName": "selectedTab",
@@ -168,9 +152,6 @@
       ],
       "name": "parameters - 1 - English"
     },
-    // French Localization: Second parameter section - French version
-    // This duplicates the RunTime parameter with French labels
-    // Shows when locale is fr-CA
     {
       "type": 9,
       "content": {
@@ -198,10 +179,6 @@
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "2023-01-16 19:55:14"
           },
-          // French Localization: DUPLICATE locale parameter (required)
-          // Must be repeated in each parameter section due to Azure Workbook scope limitations
-          // Parameters from one section aren't accessible to other sections
-          // This enables conditional visibility to work throughout the entire workbook
           {
             "id": "locale-param",
             "version": "KqlParameterItem/1.0",
@@ -218,9 +195,6 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      // French Localization: Multiple conditions for visibility (ALL must be true)
-      // 1. selectedTab != "information" - Hide when Information tab is selected
-      // 2. currentLocale == "fr-CA" - Show French version when locale is French
       "conditionalVisibilities": [
         {
           "parameterName": "selectedTab",
@@ -242,8 +216,6 @@
       },
       "name": "localization-warning"
     },
-    // French Localization: English tab navigation
-    // Shows when locale is not fr-CA
     {
       "type": 11,
       "content": {
@@ -371,8 +343,6 @@
       },
       "name": "links - 1 - English"
     },
-    // French Localization: Tab labels translated to French
-    // Shows BARRIÈRE instead of GUARDRAIL when locale is fr-CA
     {
       "type": 11,
       "content": {

--- a/setup/backend.ps1
+++ b/setup/backend.ps1
@@ -79,7 +79,8 @@ $response = Invoke-AzRestMethod -Method get -uri 'https://graph.microsoft.com/v1
 $tenantName = $response.value.displayName
 
 Add-TenantInfo -WorkSpaceID  $WorkSpaceID -WorkspaceKey $WorkspaceKey -ReportTime $ReportTime `
-               -TenantId $tenantID -DepartmentName $DepartmentName -DepartmentNumber $DepartmentNumber -tenantName $tenantName -cloudUsageProfiles $cloudUsageProfiles
+               -TenantId $tenantID -DepartmentName $DepartmentName -DepartmentNumber $DepartmentNumber -tenantName $tenantName -cloudUsageProfiles $cloudUsageProfiles `
+               -locale $Locale  # Added locale parameter for workbook French localization support
 
 # Ensure the 'Microsoft.ManagedServices' resource provider is registered under each subscription at the delegated management group
 If ($lighthouseTargetManagementGroupID) {

--- a/setup/main.ps1
+++ b/setup/main.ps1
@@ -132,12 +132,17 @@ $SubID = (Get-AzContext).Subscription.Id
 $tenantID = (Get-AzContext).Tenant.Id
 Write-Output "Reading Subscription Id from context: $SubID"
 
-# Get required variables for tenant info
+# LOCALIZATION: Get required variables for Add-TenantInfo function
+# WHY: We need to write locale to Log Analytics so the workbook can retrieve it for UI localization
+# WHAT: We're reusing the existing Add-TenantInfo function (rather than creating a new function just for locale)
+# Since Add-TenantInfo has mandatory parameters, we must provide ALL of them even though only 'locale' 
+# is relevant to our localization work. This is a trade-off to avoid modifying existing infrastructure.
 $DepartmentName = Get-GSAAutomationVariable -Name "DepartmentName"
 $DepartmentNumber = Get-GSAAutomationVariable -Name "DepartmentNumber"
 $cloudUsageProfiles = Get-GSAAutomationVariable -Name "cloudUsageProfiles"
 
-# Get tenant name from Graph API
+# LOCALIZATION: Get tenant name from Graph API (required parameter for Add-TenantInfo)
+# This value isn't available elsewhere in main.ps1, so we must fetch it from Graph API
 try {
     $response = Invoke-AzRestMethod -Method get -uri 'https://graph.microsoft.com/v1.0/organization' | Select-Object -expand Content | convertfrom-json
     $tenantName = $response.value.displayName

--- a/src/Guardrails-Common/GR-Common.psm1
+++ b/src/Guardrails-Common/GR-Common.psm1
@@ -1768,4 +1768,3 @@ function Check-BuiltInPolicies {
     return $results
 }
 
-

--- a/src/Guardrails-Common/GR-Common.psm1
+++ b/src/Guardrails-Common/GR-Common.psm1
@@ -263,7 +263,11 @@ Function Add-TenantInfo {
         $cloudUsageProfiles,
         [Parameter(Mandatory = $true)]
         [string]
-        $tenantName
+        $tenantName,
+        # Added for workbook French localization - stores locale in Log Analytics so workbook can read it
+        [Parameter(Mandatory = $false)]
+        [string]
+        $locale
     )
     $tenantInfo = Get-GSAAutomationVariable("tenantDomainUPN")
 
@@ -275,6 +279,7 @@ Function Add-TenantInfo {
         DepartmentName     = $DepartmentName
         DepartmentNumber   = $DepartmentNumber
         cloudUsageProfiles = $cloudUsageProfiles
+        locale             = $locale  # Added for workbook UI localization (fr-CA or en-CA)
     }
     if ($debug) { Write-Output $tenantInfo }
     $JSON = ConvertTo-Json -inputObject $object


### PR DESCRIPTION
## Overview/Summary

This creates French localization for some of the workbook UI elements (not all).
We have to set fr-CA for GuardrailsLocale to see these.
Column hearders remain in English (this is a more code intensive fix).
Trying to keep a balance between code complexity, functionality and maintenance.

## This PR fixes/adds/changes/removes

1. Add initalLocale and currentLocale parameters and save them in log analytics (en-CA or fr-CA)
2. The workbook UI code becomes conditional based on this parameter
3. The conditional code renders workbook as English or French based on GuardrailsLocale set
4. Removed the short form titles like "GR 1", "GR 2" etc.

### Breaking Changes

None


## Testing Evidence

**English**

<img width="1499" height="627" alt="image" src="https://github.com/user-attachments/assets/51455172-9c44-4313-825f-699df9a46063" />






<br><br>

**French**
Update both Azure language locale (to localize "Any One") and GuardrailsLocale for remaining items.

<img width="1373" height="626" alt="image" src="https://github.com/user-attachments/assets/a2307edc-135c-4f0c-a8df-9a9309aed689" />








## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
