### PR TITLE
Confirm-GSAConfigurationParameters: too strict, doesn't allow valid management group and policy set names

### DIFF
--- a/src/GuardrailsSolutionAcceleratorSetup/modules/Confirm-GSAConfigurationParameters/Confirm-GSAConfigurationParameters.psm1
+++ b/src/GuardrailsSolutionAcceleratorSetup/modules/Confirm-GSAConfigurationParameters/Confirm-GSAConfigurationParameters.psm1
@@ -176,7 +176,7 @@ Function Confirm-GSAConfigurationParameters {
         }
         AllowedLocationInitiativeId           = @{
             IsRequired       = $true
-            ValidationPattern = '^(/providers/Microsoft\.Management/managementGroups/[a-z0-9\-_]+/providers/Microsoft\.Authorization/policySetDefinitions/[a-z0-9\-_]+)|(N/A)$'
+            ValidationPattern = '^/providers/Microsoft\.Management/managementGroups/[a-z0-9]+[a-z0-9\-_.()]*[^.]+/providers/Microsoft\.Authorization/policySetDefinitions/[^<>*%&:\?.+/]*[^<>*%&:\?.+/ ]+|N/A$'
         }
         FirstBreakGlassAccountUPN         = @{
             IsRequired        = $true


### PR DESCRIPTION
## Overview/Summary

On deploying CaC, validation of parameters fails on allowedLocationInitiativeId if the policy initiative is not installed at the root management group, or the name of the policy initiative is not made up exclusively of hex digits.

## This PR fixes/adds/changes/removes

1. Issue #468 

### Breaking Changes

No breaking changes

## Testing Evidence

I took the value of allowedLocationInitiativeId in #468 which fails validation:

`"allowedLocationInitiativeId": "/providers/microsoft.management/managementgroups/dfo_operational-mg/providers/microsoft.authorization/policysetdefinitions/bestpracticesoperational"`

and replaced all of the letters that caused failure with 0 and underscore with -

`"allowedLocationInitiativeId": "/providers/microsoft.management/managementgroups/df0-00e0a0000a0-00/providers/microsoft.authorization/policysetdefinitions/be0000ac00ce000e0a0000a0"`

The above value passes validation.

Here is an example of validation failing if the name of the MG where the initiative is stored has a letter not in a-f:

`
Confirm-GSAConfigurationParameters: Parameter 'allowedLocationInitiativeId' value '/providers/microsoft.management/managementgroups/dfo-00e0a0000a0-00/providers/microsoft.authorization/policysetdefinitions/be0000ac00ce000e0a0000a0' does not match the expected pattern '(^/providers/Microsoft\.Management/managementGroups/[a-f0-9\-]+/providers/Microsoft\.Authorization/policySetDefinitions/[a-f0-9]+)|(N/A)$'.
`

It failed because I introduced the letter o in dfo.  

Here is an example  of validation failing if the name of the policy initiative does not start with a hex digit

`
Confirm-GSAConfigurationParameters: Parameter 'allowedLocationInitiativeId' value '/providers/microsoft.management/managementgroups/df0-00e0a0000a0\-00/providers/microsoft.authorization/policysetdefinitions/lockdownlocation' 
does not match the expected pattern '(^/providers/Microsoft\.Management/managementGroups/[a-f0-9\-]+/providers/Microsoft\.Authorization/policySetDefinitions/[a-f0-9]+)|(N/A)$'.
`

There is a bug int regular expression that allows for any text to precede N/A and any text to follow the first digit of the policy initiative name.  The following both pass validation but are probably unintended:
`
"allowedLocationInitiativeId": "blahN/A"
`

`
"allowedLocationInitiativeId": "/providers/microsoft.management/managementgroups/df0-00e0a0000a0-00/providers/microsoft.authorization/policysetdefinitions/best-practices-operational"
`

The pattern for matching a management group name is `[a-z0-9]+[a-z0-9\-_.()]*[^.]+` as was described [here](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftmanagement)

The pattern for matching policy initiative name is  `^[^<>*%&:\?.+/]*[^<>*%&:\?.+/ ]+$` which was found [here](https://learn.microsoft.com/en-us/azure/templates/microsoft.authorization/policysetdefinitions?pivots=deployment-language-bicep#microsoftauthorizationpolicysetdefinitions)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)