### PR TITLE
[Enhancement] - Move Check-AllUserMFARequired to bottom of module.json for allowing extra exectution time of LAW queries

### DIFF
--- a/setup/modules.json
+++ b/setup/modules.json
@@ -1,20 +1,5 @@
 [
   {
-    "ModuleName": "Check-AllUserMFARequired",
-    "Control": "Guardrails1",
-    "ModuleType": "Builtin",
-    "Status": "Enabled",
-    "Required": "True",
-    "Profiles": [1, 2, 3, 4, 5, 6],
-    "Script": "Check-AllUserMFARequired -ControlName $msgTable.CtrName1 -ItemName $msgTable.allUserAccountsMFACheck -MsgTable $msgTable -ReportTime $ReportTime -itsgcode $vars.itsgcode -CloudUsageProfiles $cloudUsageProfilesString -ModuleProfiles $ModuleProfilesString",
-    "localVariables": [
-      {
-        "Name": "itsgcode",
-        "Value": "IA2(1)"
-      }
-    ]
-  },
-  {
     "ModuleName": "Check-CloudAccountsMFA",
     "Control": "Guardrails1",
     "ModuleType": "Builtin",
@@ -1123,6 +1108,21 @@
       {
         "Name": "itsgcode",
         "Value": "AC2"
+      }
+    ]
+  },
+  {
+    "ModuleName": "Check-AllUserMFARequired",
+    "Control": "Guardrails1",
+    "ModuleType": "Builtin",
+    "Status": "Enabled",
+    "Required": "True",
+    "Profiles": [1, 2, 3, 4, 5, 6],
+    "Script": "Check-AllUserMFARequired -ControlName $msgTable.CtrName1 -ItemName $msgTable.allUserAccountsMFACheck -MsgTable $msgTable -ReportTime $ReportTime -itsgcode $vars.itsgcode -CloudUsageProfiles $cloudUsageProfilesString -ModuleProfiles $ModuleProfilesString",
+    "localVariables": [
+      {
+        "Name": "itsgcode",
+        "Value": "IA2(1)"
       }
     ]
   },


### PR DESCRIPTION
## Overview/Summary
Move Check-AllUserMFARequired to bottom of module.json for allowing extra exectution time of LAW queries related to GuardrailsUserRaw_CL. Allowing GuardrailsUserRaw_CL to exist and have as much data as possible by the time Check-AllUserMFARequired execution takes place from runbook.

## This PR fixes/adds/changes/removes
This PR enhances 
#495 

### Breaking Changes
None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).
<img width="1654" height="740" alt="image" src="https://github.com/user-attachments/assets/749da9db-0794-44e9-b31e-b07d72c74a61" />

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
