### PR TITLE
[BugFix] - GR1-Only 1 MFA auth method is required out of the approved MFA list

### DIFF
--- a/setup/IaC/modules/loganalyticsworkspace.bicep
+++ b/setup/IaC/modules/loganalyticsworkspace.bicep
@@ -134,7 +134,7 @@ let mfaAnalysis = userData
         0
     )
 | extend
-    isMfaCompliant = hasValidSystemPreferred or (hasMfaRegistered == true and validMfaMethodsCount >= 2);
+    isMfaCompliant = hasValidSystemPreferred or (hasMfaRegistered == true and validMfaMethodsCount >= 1);
 let summary = mfaAnalysis
 | summarize 
     TotalUsers = count(),
@@ -233,11 +233,10 @@ let mfaAnalysis = userData
         0
     )
 | extend
-    isMfaCompliant = hasValidSystemPreferred or (hasMfaRegistered == true and validMfaMethodsCount >= 2),
+    isMfaCompliant = hasValidSystemPreferred or (hasMfaRegistered == true and validMfaMethodsCount >= 1),
     complianceReason = case(
         hasValidSystemPreferred, strcat(tostring(localizedMessages["systemPreferred"]), strcat_array(set_intersect(systemPreferredMethodsArray, validSystemMethods), ", ")),
-        hasMfaRegistered == true and validMfaMethodsCount >= 2, strcat(tostring(localizedMessages["mfaRegistered"]), strcat_array(set_intersect(methodsRegisteredArray, validMfaMethods), ", ")),
-        hasMfaRegistered == true and validMfaMethodsCount == 1, strcat(tostring(localizedMessages["onlyOneMethod"]), strcat_array(set_intersect(methodsRegisteredArray, validMfaMethods), ", "), tostring(localizedMessages["atLeastTwoRequired"])),
+        hasMfaRegistered == true and validMfaMethodsCount >= 1, strcat(tostring(localizedMessages["mfaRegistered"]), strcat_array(set_intersect(methodsRegisteredArray, validMfaMethods), ", ")),
         hasMfaRegistered == true and validMfaMethodsCount == 0, tostring(localizedMessages["noValidMethods"]),
         tostring(localizedMessages["noMfaConfigured"])
     );


### PR DESCRIPTION
## Overview/Summary
Check-AllUserMFARequired requires only 1 MFA along with password authentication (default) i.e 2 authentication methods to be compliant.

## This PR fixes/adds/changes/removes
#635 
1. Check-AllUserMFARequired requires only 1 MFA along with password authentication (default) i.e 2 authentication methods to be compliant.

### Breaking Changes
N/A

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).
<img width="1922" height="791" alt="image" src="https://github.com/user-attachments/assets/5be25da3-6a19-4c72-bc90-f71ddd9c08b2" />


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
