### PR TITLE
[BugFix] - Fix when systempreferredauthentication method is not set for any user

### DIFF
--- a/setup/IaC/modules/loganalyticsworkspace.bicep
+++ b/setup/IaC/modules/loganalyticsworkspace.bicep
@@ -121,7 +121,8 @@ let mfaAnalysis = userData
 | extend 
     sysPreferredValue = column_ifexists("systemPreferredAuthenticationMethods_s", ""),
     methodsRegisteredValue = column_ifexists("methodsRegistered_s", ""),
-    isSystemPreferredEnabled = tobool(column_ifexists("isSystemPreferredAuthenticationMethodEnabled_b", "false")),
+    isSystemPreferredEnabled = tobool(column_ifexists("isSystemPreferredAuthenticationMethodEnabled_b", "false"))
+| extend
     systemPreferredMethodsArray = iff(
         isnotempty(sysPreferredValue) and sysPreferredValue startswith "[",
         parse_json(sysPreferredValue),
@@ -232,7 +233,8 @@ let mfaAnalysis = userData
 | extend 
     sysPreferredValue = column_ifexists("systemPreferredAuthenticationMethods_s", ""),
     methodsRegisteredValue = column_ifexists("methodsRegistered_s", ""),
-    isSystemPreferredEnabled = tobool(column_ifexists("isSystemPreferredAuthenticationMethodEnabled_b", "false")),
+    isSystemPreferredEnabled = tobool(column_ifexists("isSystemPreferredAuthenticationMethodEnabled_b", "false"))
+| extend
     systemPreferredMethodsArray = iff(
         isnotempty(sysPreferredValue) and sysPreferredValue startswith "[",
         parse_json(sysPreferredValue),


### PR DESCRIPTION
## Overview/Summary

This PR fixes situations where systemPreferredAuthenticationMethod is not set for any user which leads to this column not getting created at all in LAW table, thereby leading to exceptions in both `gr_mfa_evaluation`  and `gr_non_mfa_users` saved searches

## This PR fixes/adds/changes/removes
Fixes #648 
1. Fix: Adds defensive defaults for column_ifexists for systemPreferredAuthenticationMethods if column doesnt exists  `### Breaking Changes

## Breaking Changes
1. None. These are defensive changes only and preserve previous behavior when Graph returns those fields.

## Testing Evidence
- Tested this on the client where this was occuring, fixed existing issue.
<img width="1594" height="678" alt="image" src="https://github.com/user-attachments/assets/45f6e090-2f53-4d92-9f61-ca32f7fc0779" />


## As part of this Pull Request I have

- [x] Checked for duplicate Pull Requests
- [x] Associated it with relevant GitHub Issues (link in PR description)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` branch
- [x] Performed testing and provided evidence above
- [ ] Updated relevant documentation (inline comments added)
- [ ] Ensured PowerShell module versions have been updated if required
