### PR TITLE
[Fix] - update the Central aggregation of client logs starting later at 7AM ET

### DIFF
--- a/tools/CentralView/grtimerfunction/function.json
+++ b/tools/CentralView/grtimerfunction/function.json
@@ -4,7 +4,7 @@
       "name": "Timer",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 0 10 * * *"
+      "schedule": "0 0 12 * * *"
     }
   ]
 }


### PR DESCRIPTION
Overview/Summary
[#669](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues/669)
This fix is to change the schedule for Central aggregation of client logs starting later at 7AM ET daily. It will be giving more of an opportunity for client runs to be completed. Gap between client run and central aggregation increase from 3 hours to 5 hours.

This PR fixes/adds/changes/removes
Change the cron job schedule for function - grtimerfunction in Function App

Breaking Changes
N/A

Testing Evidence

<img width="477" height="417" alt="image" src="https://github.com/user-attachments/assets/995afe4d-4ff9-466b-a338-8e06a9814dc0" />


## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
