### PR TITLE
zipemall.ps1 not updating the GR-ComplianceChecks psmodule correctly

### DIFF
--- a/tools/zipemall.ps1
+++ b/tools/zipemall.ps1
@@ -47,11 +47,18 @@ ForEach ($moduleManifest in $moduleManifestFilesObjs) {
             Write-Host "Copied code file: $codeFile to $($tempDir.FullName)"
         }
         
-        # Copy any additional files in the same directory with the same base name
-        $additionalFiles = Get-ChildItem -Path $moduleManifest.Directory -File | Where-Object { $_.BaseName -eq $moduleManifest.BaseName -and $_.Extension -notin @('.psd1', '.psm1') }
+        # Copy any additional files in the same directory that start with the module base name (e.g., GR-ComplianceChecks-Msgs.psd1)
+        $additionalFiles = Get-ChildItem -Path $moduleManifest.Directory -File | Where-Object { $_.Name -like "$($moduleManifest.BaseName)-*" -or ($_.BaseName -eq $moduleManifest.BaseName -and $_.Extension -notin @('.psd1', '.psm1')) }
         foreach ($file in $additionalFiles) {
             Copy-Item -Path $file.FullName -Destination $tempDir -Force
             Write-Host "Copied additional file: $($file.FullName) to $($tempDir.FullName)"
+        }
+        
+        # Copy any subdirectories that match culture/locale patterns (e.g., fr-CA, en-US for localization)
+        $subDirectories = Get-ChildItem -Path $moduleManifest.Directory -Directory | Where-Object { $_.Name -match '^[a-z]{2}-[A-Z]{2}$' }
+        foreach ($subDir in $subDirectories) {
+            Copy-Item -Path $subDir.FullName -Destination $tempDir -Recurse -Force
+            Write-Host "Copied subdirectory: $($subDir.FullName) to $($tempDir.FullName)"
         }
         
         # List files in temporary directory


### PR DESCRIPTION
## Overview/Summary

Updated the zipemall.ps1 to include additional files that pertain to Locale

## This PR fixes/adds/changes/removes

1. zipemall.ps1

### Breaking Changes

N/A

<img width="711" height="450" alt="image" src="https://github.com/user-attachments/assets/2288f887-f84c-4b95-9391-e5903934fe8c" />

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
