### PR TITLE
[Bugfix] In v3.0.0beta Summary View: Only show mandatory compliance tables when Show Recommended button set to No

### DIFF
--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -2477,6 +2477,11 @@
             "parameterName": "selectedTab",
             "comparison": "isEqualTo",
             "value": "summary"
+            },
+            {
+            "parameterName": "RequiredYesNo",
+            "comparison": "isEqualTo",
+            "value": "Other"
             }
        ],
        "name": "Overall Compliance Status by Guardrail (Mandatory + Recommended)",


### PR DESCRIPTION
## Overview/Summary

If "Show Recommended Compliance" button set to "NO", only show mandatory compliance tables, hide "Overall Compliance Status by Guardrail (Mandatory + Recommended)" table.

## This PR fixes/adds/changes/removes
Modify gr.workbook, for "Overall Compliance Status by Guardrail (Mandatory + Recommended)" section, add additional conditional visibilities .

### Breaking Changes

N/A

## Testing Evidence

<img width="764" height="405" alt="image" src="https://github.com/user-attachments/assets/7a54f882-b613-43cd-96f5-34caffb7646e" />

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
