### PR TITLE
[Enhancement] GR1 Add hardwareonetimepasscode as valid mfa

### DIFF
--- a/setup/IaC/modules/loganalyticsworkspace.bicep
+++ b/setup/IaC/modules/loganalyticsworkspace.bicep
@@ -325,7 +325,7 @@ let guestsToEvaluate = guestsWithTrustInfo
 let excludedGuestCount = toscalar(guestsToExclude | summarize count());
 let userData = union memberUsers, guestsToEvaluate;
 let validSystemMethods = dynamic(["Fido2", "HardwareOTP"]);
-let validMfaMethods = dynamic(["microsoftAuthenticatorPush", "mobilePhone", "softwareOneTimePasscode", "passKeyDeviceBound", "windowsHelloForBusiness", "fido2SecurityKey", "passKeyDeviceBoundAuthenticator", "passKeyDeviceBoundWindowsHello", "temporaryAccessPass"]);
+let validMfaMethods = dynamic(["microsoftAuthenticatorPush", "mobilePhone", "softwareOneTimePasscode", "hardwareOneTimePasscode", "passKeyDeviceBound", "windowsHelloForBusiness", "fido2SecurityKey", "passKeyDeviceBoundAuthenticator", "passKeyDeviceBoundWindowsHello", "temporaryAccessPass"]);
 let mfaAnalysis = userData
 | extend 
     sysPreferredValue = column_ifexists("systemPreferredAuthenticationMethods_s", ""),
@@ -486,7 +486,7 @@ let userData = GuardrailsUserRaw_CL
 | where ReportTime == reportTime
 | where guardrailsExcluded == false;
 let validSystemMethods = dynamic(["Fido2", "HardwareOTP"]);
-let validMfaMethods = dynamic(["microsoftAuthenticatorPush", "mobilePhone", "softwareOneTimePasscode", "passKeyDeviceBound", "windowsHelloForBusiness", "fido2SecurityKey", "passKeyDeviceBoundAuthenticator", "passKeyDeviceBoundWindowsHello", "temporaryAccessPass"]);
+let validMfaMethods = dynamic(["microsoftAuthenticatorPush", "mobilePhone", "softwareOneTimePasscode", "hardwareOneTimePasscode", "passKeyDeviceBound", "windowsHelloForBusiness", "fido2SecurityKey", "passKeyDeviceBoundAuthenticator", "passKeyDeviceBoundWindowsHello", "temporaryAccessPass"]);
 let mfaAnalysis = userData
 | extend 
     sysPreferredValue = column_ifexists("systemPreferredAuthenticationMethods_s", ""),


### PR DESCRIPTION
## Overview/Summary
Adds `hardwareOneTimePasscode` as a recognized valid MFA authentication method in the KQL saved search queries used for Guardrail 1 (GR1) MFA compliance evaluation. Without this change, users registered with a hardware OATH token (one-time passcode) were not counted as MFA-compliant, causing false-negative non-compliance results.

## This PR fixes/adds/changes/removes
fixes #725 
1. Added `hardwareOneTimePasscode` to the `validMfaMethods` list in the `gr_mfa_evaluation` KQL saved search (`loganalyticsworkspace.bicep`).
2. Added `hardwareOneTimePasscode` to the `validMfaMethods` list in the `gr_non_mfa_users` KQL saved search (`loganalyticsworkspace.bicep`).

### Breaking Changes
1. None — this is an additive change; existing compliant users are unaffected. Users previously evaluated as non-compliant due to using hardware OATH tokens will now correctly be marked as compliant.

## Testing Evidence
<img width="1595" height="695" alt="image" src="https://github.com/user-attachments/assets/d04b8d2b-5642-4966-a30d-31e9c5710313" />

## As part of this Pull Request I have
- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)