### PR TITLE
[Enhancement] Set Recommended Controls default option to No

### DIFF
--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -29,7 +29,7 @@
             "timeContext": {
               "durationMs": 86400000
             },
-            "value": "Other"
+            "value": "False"
           }
         ],
         "style": "pills",


### PR DESCRIPTION
## Overview/Summary

Switch Show Recommended Controls default option to "No" from "Yes"

## This PR fixes/adds/changes/removes

Change default value for "Show Recommended Controls" in setup/IaC/modules/gr.workbook

### Breaking Changes

N/A

## Testing Evidence

<img width="225" height="43" alt="image" src="https://github.com/user-attachments/assets/1f94176c-29f1-411a-ada9-79a3bc80557f" />

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
