### PR TITLE
[BugFix] - Add dependson to ensure tables are ready before dcrdce is created

### DIFF
--- a/setup/IaC/guardrails.bicep
+++ b/setup/IaC/guardrails.bicep
@@ -135,6 +135,7 @@ module DCRDCE 'modules/dcrdce.bicep' = if (deployLAW && (newDeployment || update
     location: location
     #disable-next-line BCP318    
     logAnalyticsWorkspaceResourceId: LAW.outputs.logAnalyticsResourceId
+    logAnalyticsWorkspaceName: logAnalyticsWorkspaceName
     releaseVersion: releaseVersion
     releaseDate: releaseDate
     newDeployment: newDeployment

--- a/setup/IaC/modules/dcrdce.bicep
+++ b/setup/IaC/modules/dcrdce.bicep
@@ -3,12 +3,71 @@
 
 param location string
 param logAnalyticsWorkspaceResourceId string
+// Workspace name is used to declare table existing-resource references so ARM enforces
+// resource-level readiness before the DCR is created or updated (prevents InvalidOutputTable).
+param logAnalyticsWorkspaceName string
 param dceName string = 'guardrails-dce'
 param dcrName string = 'guardrails-dcr'
 param releaseVersion string
 param releaseDate string
 param newDeployment bool = true
 param updateCoreResources bool = false
+
+// ── Existing-resource references for every DCR output table ──────────────────
+// Declaring these as 'existing' and adding them to the DCR dependsOn tells ARM
+// to wait until each table is in Succeeded state before provisioning the DCR,
+// preventing the race condition where tables are still updating when the DCR runs.
+resource lawWorkspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
+  name: logAnalyticsWorkspaceName
+}
+resource tableGuardrailsCompliance 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' existing = {
+  parent: lawWorkspace
+  name: 'GuardrailsCompliance_CL'
+}
+resource tableGuardrailsComplianceException 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' existing = {
+  parent: lawWorkspace
+  name: 'GuardrailsComplianceException_CL'
+}
+resource tableGR_TenantInfo 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' existing = {
+  parent: lawWorkspace
+  name: 'GR_TenantInfo_CL'
+}
+resource tableGR_Results 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' existing = {
+  parent: lawWorkspace
+  name: 'GR_Results_CL'
+}
+resource tableGR_VersionInfo 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' existing = {
+  parent: lawWorkspace
+  name: 'GR_VersionInfo_CL'
+}
+resource tableGRITSGControls 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' existing = {
+  parent: lawWorkspace
+  name: 'GRITSGControls_CL'
+}
+resource tableGuardrailsTenantsCompliance 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' existing = {
+  parent: lawWorkspace
+  name: 'GuardrailsTenantsCompliance_CL'
+}
+resource tableCaCDebugMetrics 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' existing = {
+  parent: lawWorkspace
+  name: 'CaCDebugMetrics_CL'
+}
+resource tableGuardrailsUserRaw 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' existing = {
+  parent: lawWorkspace
+  name: 'GuardrailsUserRaw_CL'
+}
+resource tableGuardrailsCrossTenantAccess 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' existing = {
+  parent: lawWorkspace
+  name: 'GuardrailsCrossTenantAccess_CL'
+}
+resource tableGR2UsersWithoutGroups 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' existing = {
+  parent: lawWorkspace
+  name: 'GR2UsersWithoutGroups_CL'
+}
+resource tableGR2ExternalUsers 'Microsoft.OperationalInsights/workspaces/tables@2022-10-01' existing = {
+  parent: lawWorkspace
+  name: 'GR2ExternalUsers_CL'
+}
 
 // Data Collection Endpoint (DCE)
 // Create/update DCE on new deployments or when updating core resources (for migration)
@@ -39,6 +98,23 @@ resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2024-03-11' 
     releaseDate: releaseDate
   }
   kind: 'Direct'
+  // Wait for every output-stream table to reach Succeeded before ARM validates the DCR.
+  // Module-level dependsOn alone (deployment granularity) is insufficient — ARM can mark a
+  // deployment Succeeded while individual table resources are still in Updating state.
+  dependsOn: [
+    tableGuardrailsCompliance
+    tableGuardrailsComplianceException
+    tableGR_TenantInfo
+    tableGR_Results
+    tableGR_VersionInfo
+    tableGRITSGControls
+    tableGuardrailsTenantsCompliance
+    tableCaCDebugMetrics
+    tableGuardrailsUserRaw
+    tableGuardrailsCrossTenantAccess
+    tableGR2UsersWithoutGroups
+    tableGR2ExternalUsers
+  ]
   properties: {
     dataCollectionEndpointId: dataCollectionEndpoint.id
     dataFlows: [
@@ -679,6 +755,10 @@ resource dataCollectionRule2 'Microsoft.Insights/dataCollectionRules@2024-03-11'
     releaseDate: releaseDate
   }
   kind: 'Direct'
+  dependsOn: [
+    tableGR2UsersWithoutGroups
+    tableGR2ExternalUsers
+  ]
   properties: {
     dataCollectionEndpointId: dataCollectionEndpoint.id
     dataFlows: [


### PR DESCRIPTION
## Overview/Summary

Fixes a deployment race condition where the Data Collection Rule (`guardrails-dcrdce`) fails with
`InvalidOutputTable` / `InvalidPayload` because ARM's DCR provisioning validates Log Analytics
custom table readiness at the resource level, and those tables may still be in a transitioning
state when the DCR deployment starts — even after the `guardrails-loganalytics` module deployment
is marked `Succeeded`.

## This PR fixes/adds/changes/removes
fixes #822 
1. **Fixes** `setup/IaC/modules/dcrdce.bicep` — adds `existing` resource declarations for all 12
   DCR output tables (`GuardrailsCompliance_CL`, `GuardrailsComplianceException_CL`,
   `GR_TenantInfo_CL`, `GR_Results_CL`, `GR_VersionInfo_CL`, `GRITSGControls_CL`,
   `GuardrailsTenantsCompliance_CL`, `CaCDebugMetrics_CL`, `GuardrailsUserRaw_CL`,
   `GuardrailsCrossTenantAccess_CL`, `GR2UsersWithoutGroups_CL`, `GR2ExternalUsers_CL`) and adds
   explicit `dependsOn` on those references to both `dataCollectionRule` and `dataCollectionRule2`,
   forcing ARM to wait for each table to reach `Succeeded` state before provisioning the DCR.
2. **Adds** `param logAnalyticsWorkspaceName string` to `setup/IaC/modules/dcrdce.bicep` to
   allow the workspace `existing` reference to be resolved.
3. **Updates** `setup/IaC/guardrails.bicep` to pass `logAnalyticsWorkspaceName` to the `DCRDCE`
   module.

### Breaking Changes

1. None — no infrastructure is added, removed, or modified by this change. The `existing`
   declarations are compile-time symbols only; they create no ARM resources and do not alter any
   existing ones. Deployments that were already succeeding will continue to succeed.

## Disclosure of AI assistance
N/A

## Testing Evidence

Redeployd on a branch off `main-interim` and confirm all four deployments (`guardrails-loganalytics`, `guardrails-storageaccount`, `guardrails-dcrdce`, `guardrailsdeployment`) complete with `Succeeded` status and no
`InvalidOutputTable` / `InvalidPayload` errors.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)