### PR TITLE
[Enhancement] Increase report time duration

### DIFF
--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -58,12 +58,24 @@
               "showDefault": false
             },
             "timeContext": {
-              "durationMs": 86400000
+              "durationMs": "{Lookback}"
             },
             "defaultValue": "value::1",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "2023-01-16 19:55:14"
+          },
+          {
+            "id": "f3b2d0e3-7b6e-4b7a-b1a4-ffb1c62a2e91",
+            "version": "KqlParameterItem/1.0",
+            "name": "Lookback",
+            "label": "Lookback Interval",
+            "type": 2,
+            "isRequired": true,
+            "query": "datatable(Value:string, Label:string)\n[\n  \"P1D\", \"24 hours\",\n  \"P7D\", \"⏳ 7 days\",\n  \"P30D\", \"📅 30 days\"\n]",
+            "defaultValue": "P7D",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "pills",

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -58,24 +58,12 @@
               "showDefault": false
             },
             "timeContext": {
-              "durationMs": "{Lookback}"
+              "durationMs": 2592000000
             },
             "defaultValue": "value::1",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "2023-01-16 19:55:14"
-          },
-          {
-            "id": "f3b2d0e3-7b6e-4b7a-b1a4-ffb1c62a2e91",
-            "version": "KqlParameterItem/1.0",
-            "name": "Lookback",
-            "label": "Lookback Interval",
-            "type": 2,
-            "isRequired": true,
-            "query": "datatable(Value:string, Label:string)\n[\n  \"P1D\", \"24 hours\",\n  \"P7D\", \"⏳ 7 days\",\n  \"P30D\", \"📅 30 days\"\n]",
-            "defaultValue": "P7D",
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "pills",


### PR DESCRIPTION
## Overview/Summary

This Pull Request increase Report Time duration from 24 hours to 30 days So user can see and view any reports generated within 30 days in the report time list of the workbook. This change may be the best solution to meet client's requirement to view 7 days or 30 days report after research and testing.

## This PR fixes/adds/changes/removes

Increase duration time from 24 hours to 30 days in gr.workbook file

### Breaking Changes
N/A

## Testing Evidence
<img width="259" height="399" alt="image" src="https://github.com/user-attachments/assets/ba102939-5928-4d33-b681-a28893941044" />

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
