### PR TITLE
[Bugfix] replace CurrentVersion_s with DeployedVersion_s for new version alert query

### DIFF
--- a/setup/IaC/guardrails.bicep
+++ b/setup/IaC/guardrails.bicep
@@ -137,7 +137,7 @@ module alertNewVersion 'modules/alert.bicep' = {
     alertRuleDisplayName: 'Guardrails New Version Available.'
     alertRuleSeverity: 3
     location: location
-    query: 'GR_VersionInfo_CL | summarize total=count() by UpdateAvailable=iff(CurrentVersion_s != AvailableVersion_s, "Yes",\'No\') | where UpdateAvailable == \'Yes\''
+    query: 'GR_VersionInfo_CL | summarize total=count() by UpdateAvailable=iff(DeployedVersion_s != AvailableVersion_s, "Yes",\'No\') | where UpdateAvailable == \'Yes\''
     scope: LAW.outputs.logAnalyticsResourceId
     autoMitigate: true
     evaluationFrequency: 'PT6H'

--- a/setup/IaC/testAlert.bicep
+++ b/setup/IaC/testAlert.bicep
@@ -13,7 +13,7 @@ resource featuresTable 'Microsoft.OperationalInsights/workspaces/tables@2022-10-
         name: 'GR_VersionInfo_CL'
         columns: [
             {
-                name: 'CurrentVersion_s'
+                name: 'DeployedVersion_s'
                 type: 'string'
             }
             {
@@ -45,7 +45,7 @@ module alertNewVersion 'modules/alert.bicep' = {
       alertRuleDisplayName: 'Guardrails New Version Available.'
       alertRuleSeverity: 3
       location: location
-      query: 'GR_VersionInfo_CL | summarize total=count() by UpdateAvailable=iff(CurrentVersion_s != AvailableVersion_s, "Yes",\'No\') | where UpdateAvailable == \'Yes\''
+      query: 'GR_VersionInfo_CL | summarize total=count() by UpdateAvailable=iff(DeployedVersion_s != AvailableVersion_s, "Yes",\'No\') | where UpdateAvailable == \'Yes\''
       scope: lawId
       autoMitigate: true
       evaluationFrequency: 'PT6H'


### PR DESCRIPTION
## Overview/Summary

This code change is to fix Azure monitor alert fails to run due to a missing column ( CurrentVersion_s) within the GR_VersionInfo_CL Table

## This PR fixes/adds/changes/removes

Replace CurrentVersion_s with DeployedVersion_s in guardrails.bicep and testAlert.bicep

### Breaking Changes

n/a

## Testing Evidence

<img width="643" height="71" alt="image" src="https://github.com/user-attachments/assets/a79573ed-767c-459c-87c3-cbafcc7e4f15" />


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
