### PR TITLE
[Update] Remove OMS Ingestion API package (for 4.0.0)

### DIFF
--- a/setup/IaC/modules/automationaccount.bicep
+++ b/setup/IaC/modules/automationaccount.bicep
@@ -47,14 +47,6 @@ resource guardrailsAC 'Microsoft.Automation/automationAccounts@2023-11-01' = if 
         identity: {}
     }
   }
-  resource OMSModule 'powerShell72Modules' = if (newDeployment || updatePSModules) {
-    name: 'OMSIngestionAPI'
-    properties: {
-      contentLink: {
-        uri: 'https://devopsgallerystorage.blob.core.windows.net/packages/omsingestionapi.1.6.0.nupkg'
-        version: '1.6.0'
-      }}
-  }
   resource module1 'powerShell72Modules' = if (newDeployment || updatePSModules) {
     name: 'Check-BreakGlassAccountOwnersInformation'
     properties: {


### PR DESCRIPTION
## Overview/Summary

This Pull Request removes the OMS Ingestion API package from the CaC codebase. 
Thus it can prevents the error after data collector API deprecation on September 14, 2026

## This PR fixes/adds/changes/removes

This Pull Request removes the OMS Ingestion API package from the CaC codebase. 

## Breaking Changes

N/A

## Disclosure of AI assistance

N/A


## Testing Evidence

Sucessfully deployed.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)