### PR TITLE
[BugFix] Fix Report time bug to show any reports in 30 days for release 4.0.0

### DIFF
--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -27,7 +27,7 @@
             },
             "jsonData": "[\n    { \"value\":\"Other\", \"label\":\"Yes\" },\n    { \"value\":\"False\", \"label\":\"No\", \"selected\":true }\n]",
             "timeContext": {
-              "durationMs": 86400000
+              "durationMs": 2592000000
             },
             "value": "False"
           }
@@ -215,7 +215,7 @@
         "size": 0,
         "title": "GR 1",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -268,7 +268,7 @@
         "size": 4,
         "title": "Guardrail 1 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -309,7 +309,7 @@
         "size": 4,
         "title": "Guardrail 1 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -380,7 +380,7 @@
             },
             "jsonData": "[\n    { \"value\":\"yes\", \"label\":\"Yes\" },\n    { \"value\":\"no\", \"label\":\"No\", \"selected\":true }\n]",
             "timeContext": {
-              "durationMs": 86400000
+              "durationMs": 2592000000
             }
           }
         ],
@@ -402,7 +402,7 @@
         "query": "gr_non_mfa_users('{RunTime}','__MFA_GRACE_PERIOD__')",
         "size": 0,
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
@@ -429,7 +429,7 @@
         "size": 0,
         "title": "GR 2",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -482,7 +482,7 @@
         "size": 4,
         "title": "Guardrail 2 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -523,7 +523,7 @@
         "size": 4,
         "title": "Guardrail 2 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -581,7 +581,7 @@
             },
             "jsonData": "[\n    { \"value\":\"yes\", \"label\":\"Yes\" },\n    { \"value\":\"no\", \"label\":\"No\", \"selected\":true }\n]",
             "timeContext": {
-              "durationMs": 86400000
+              "durationMs": 2592000000
             }
           }
         ],
@@ -603,7 +603,7 @@
         "query": "GR2ExternalUsers_CL \n| where column_ifexists(\"ReportTime_s\", \"\") == \"{RunTime}\"\n| project \n    DisplayName_s = column_ifexists(\"DisplayName_s\", \"\"),\n    Mail_s = column_ifexists(\"Mail_s\", \"\"),\n    Subscription_s = column_ifexists(\"Subscription_s\", \"\"),\n    Role_s = column_ifexists(\"Role_s\", \"\"),\n    PrivilegedRole_s = column_ifexists(\"PrivilegedRole_s\", \"\"),\n    Comments_s = column_ifexists(\"Comments_s\", \"\")",
         "size": 0,
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
@@ -640,7 +640,7 @@
             },
             "jsonData": "[\n    { \"value\":\"yes\", \"label\":\"Yes\" },\n    { \"value\":\"no\", \"label\":\"No\", \"selected\":true }\n]",
             "timeContext": {
-              "durationMs": 86400000
+              "durationMs": 2592000000
             }
           }
         ],
@@ -675,7 +675,7 @@
         "query": "GR2UsersWithoutGroups_CL \n| where column_ifexists(\"ReportTime_s\", \"\") == \"{RunTime}\"\n| project \n    DisplayName_s = column_ifexists(\"DisplayName_s\", \"\"),\n    UserPrincipalName_s = column_ifexists(\"UserPrincipalName_s\", \"\"),\n    Comments_s = column_ifexists(\"Comments_s\", \"\")",
         "size": 0,
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
@@ -702,7 +702,7 @@
         "size": 0,
         "title": "GR 3",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -755,7 +755,7 @@
         "size": 4,
         "title": "Guardrail 3 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -796,7 +796,7 @@
         "size": 4,
         "title": "Guardrail 3 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -844,7 +844,7 @@
         "size": 0,
         "title": "GR 4",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -897,7 +897,7 @@
         "size": 4,
         "title": "Guardrail 4 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -938,7 +938,7 @@
         "size": 4,
         "title": "Guardrail 4 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -986,7 +986,7 @@
         "size": 0,
         "title": "GR 5",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1037,7 +1037,7 @@
         "size": 4,
         "title": "Guardrail 5 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1078,7 +1078,7 @@
         "size": 4,
         "title": "Guardrail 5 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1126,7 +1126,7 @@
         "size": 0,
         "title": "GR 6",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "exportToExcelOptions": "all",
         "queryType": 0,
@@ -1178,7 +1178,7 @@
         "size": 4,
         "title": "Guardrail 6 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1219,7 +1219,7 @@
         "size": 4,
         "title": "Guardrail 6 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1267,7 +1267,7 @@
         "size": 0,
         "title": "GR 7",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1318,7 +1318,7 @@
         "size": 4,
         "title": "Guardrail 7 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1359,7 +1359,7 @@
         "size": 4,
         "title": "Guardrail 7 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1403,11 +1403,11 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 8\";\r\nGuardrailsCompliance_CL\r\n| where column_ifexists(\"ControlName_s\", \"\") has ctrlprefix  and column_ifexists(\"ReportTime_s\", \"\") == \"{RunTime}\" and column_ifexists(\"Required_s\", \"\") != tostring(\"{RequiredYesNo}\")\r\n| where TimeGenerated > ago (24h)\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project \r\n    ['Item Name'] = strcat(iff(column_ifexists(\"Required_s\", \"\")==\"False\",\"(R) \", \"(M) \"), column_ifexists(\"ItemName_s\", \"\")),\r\n    ['Subscription Name'] = column_ifexists(\"SubscriptionName_s\", \"\"),\r\n    ['Subnet Name'] = column_ifexists(\"SubnetName_s\", \"\"),\r\n    Status = case(column_ifexists(\"ComplianceStatus_b\", bool(null)) == true, \"✔️\", column_ifexists(\"ComplianceStatus_b\", bool(null)) == false, \"❌\", \"➖\"),\r\n    Comments = column_ifexists(\"Comments_s\", \"\"),\r\n    ['ITSG Control'] = column_ifexists(\"itsgcode_s\", \"\"),\r\n    Remediation = gr_geturl(replace_string(ctrlprefix,\" \",\"\"), column_ifexists(\"itsgcode_s\", \"\")),\r\n    Profile = iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')\r\n| sort by Status asc",
+        "query": "let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\r\nlet ctrlprefix=\"GUARDRAIL 8\";\r\nGuardrailsCompliance_CL\r\n| where column_ifexists(\"ControlName_s\", \"\") has ctrlprefix  and column_ifexists(\"ReportTime_s\", \"\") == \"{RunTime}\" and column_ifexists(\"Required_s\", \"\") != tostring(\"{RequiredYesNo}\")\r\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project \r\n    ['Item Name'] = strcat(iff(column_ifexists(\"Required_s\", \"\")==\"False\",\"(R) \", \"(M) \"), column_ifexists(\"ItemName_s\", \"\")),\r\n    ['Subscription Name'] = column_ifexists(\"SubscriptionName_s\", \"\"),\r\n    ['Subnet Name'] = column_ifexists(\"SubnetName_s\", \"\"),\r\n    Status = case(column_ifexists(\"ComplianceStatus_b\", bool(null)) == true, \"✔️\", column_ifexists(\"ComplianceStatus_b\", bool(null)) == false, \"❌\", \"➖\"),\r\n    Comments = column_ifexists(\"Comments_s\", \"\"),\r\n    ['ITSG Control'] = column_ifexists(\"itsgcode_s\", \"\"),\r\n    Remediation = gr_geturl(replace_string(ctrlprefix,\" \",\"\"), column_ifexists(\"itsgcode_s\", \"\")),\r\n    Profile = iff(isnotempty(column_ifexists('Profile_d', '')), tostring(toint(column_ifexists('Profile_d', ''))), '')\r\n| sort by Status asc",
         "size": 0,
         "title": "GR 8",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1458,7 +1458,7 @@
         "size": 4,
         "title": "Guardrail 8 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1499,7 +1499,7 @@
         "size": 4,
         "title": "Guardrail 8 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1547,7 +1547,7 @@
         "size": 0,
         "title": "GR 9",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1606,7 +1606,7 @@
         "size": 4,
         "title": "Guardrail 9 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1647,7 +1647,7 @@
         "size": 4,
         "title": "Guardrail 9 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1695,7 +1695,7 @@
         "size": 0,
         "title": "GR 10",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1748,7 +1748,7 @@
         "size": 4,
         "title": "Guardrail 10 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1789,7 +1789,7 @@
         "size": 4,
         "title": "Guardrail 10 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1837,7 +1837,7 @@
         "size": 0,
         "title": "GR 11",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1896,7 +1896,7 @@
         "size": 4,
         "title": "Guardrail 11 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1937,7 +1937,7 @@
         "size": 4,
         "title": "Guardrail 11 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1985,7 +1985,7 @@
         "size": 0,
         "title": "GR 12",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2038,7 +2038,7 @@
         "size": 4,
         "title": "Guardrail 12 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2079,7 +2079,7 @@
         "size": 4,
         "title": "Guardrail 12 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2127,7 +2127,7 @@
         "size": 0,
         "title": "GR 13",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2180,7 +2180,7 @@
         "size": 4,
         "title": "Guardrail 13 Mandatory Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2221,7 +2221,7 @@
         "size": 4,
         "title": "Guardrail 13 Recommended Compliance",
         "timeContext": {
-            "durationMs": 86400000
+            "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2269,7 +2269,7 @@
         "size": 3,
         "title": "Overall Mandatory Compliance",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2332,7 +2332,7 @@
         "size": 3,
         "title": "Overall Recommended Compliance",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2399,11 +2399,11 @@
       "name": "Overall Compliance Status",
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_summary(\"{RunTime}\", 24)",
+        "query": "gr_summary(\"{RunTime}\")",
         "size": 4,
         "title": "Overall Compliance Status",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2444,11 +2444,11 @@
       "name": "Overall Compliance Status by Guardrail (Mandatory + Recommended)",
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_summary_by_prefix_alla(\"{RunTime}\", 24, \"\")",
+        "query": "gr_summary_by_prefix_alla(\"{RunTime}\", \"\")",
         "size": 0,
         "title": "Overall Compliance Status by Guardrail (Mandatory + Recommended)",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2494,11 +2494,11 @@
       "name": "Compliance Status by Guardrail (Mandatory Controls)",
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_summary_by_prefix_all(\"{RunTime}\", 24, true)",
+        "query": "gr_summary_by_prefix_all(\"{RunTime}\", true)",
         "size": 0,
         "title": "Compliance Status by Guardrail (Mandatory Controls)",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2539,11 +2539,11 @@
       "name": "Compliance Status by Guardrail (Recommended Controls)",
       "content": {
         "version": "KqlItem/1.0",
-        "query": "gr_summary_by_prefix_all(\"{RunTime}\", 24, false)",
+        "query": "gr_summary_by_prefix_all(\"{RunTime}\", false)",
         "size": 0,
         "title": "Compliance Status by Guardrail (Recommended Controls)",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2591,7 +2591,7 @@
         "query": "GuardrailsCompliance_CL\n| where column_ifexists(\"ReportTime_s\", \"\") == '{RunTime}'\n| summarize by column_ifexists(\"ControlName_s\", \"\")\n| count \n| extend Title=\"Total # of Items\"",
         "size": 4,
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2629,7 +2629,7 @@
         "size": 4,
         "title": "Guardrails Version Information",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
@@ -2649,7 +2649,7 @@
         "size": 4,
         "title": "Cloud Usage Profile Configuration",
         "timeContext": {
-          "durationMs": 86400000
+          "durationMs": 2592000000
         },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"

--- a/setup/IaC/modules/loganalyticsworkspace.bicep
+++ b/setup/IaC/modules/loganalyticsworkspace.bicep
@@ -800,7 +800,7 @@ resource f2 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-08-01' 
   properties: {
     category: 'gr_functions'
     displayName: 'gr_data'
-    query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n| where TimeGenerated > ago (24h)\n|join kind=leftouter (itsgcodes) on itsgcode_s\n| project ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="false","(R) ", "(M) "), column_ifexists("ItemName_s", "")),\n    Comments=column_ifexists("Comments_s", ""),\n    Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'),\n    ["ITSG Control"]=column_ifexists("itsgcode_s", ""),\n    Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")),\n    Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
+    query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n|join kind=leftouter (itsgcodes) on itsgcode_s\n| project ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="false","(R) ", "(M) "), column_ifexists("ItemName_s", "")),\n    Comments=column_ifexists("Comments_s", ""),\n    Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'),\n    ["ITSG Control"]=column_ifexists("itsgcode_s", ""),\n    Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")),\n    Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
     functionAlias: 'gr_data'
     functionParameters: 'ctrlprefix:string, ReportTime:string, showNonRequired:string'
     version: 2
@@ -813,7 +813,7 @@ resource gr3 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-08-01'
     category: 'gr_functions'
     displayName: 'gr_data3'
     // Profile gating removed from this query so profile 1 rows are not hidden in workbook output.
-    query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n| where TimeGenerated > ago (24h)\n|join kind=leftouter (itsgcodes) on itsgcode_s\n| project ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="False","(R) ", "(M) "), column_ifexists("ItemName_s", "")),\n    Comments=column_ifexists("Comments_s", ""),\n    Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'),\n    ["ITSG Control"]=column_ifexists("itsgcode_s", ""),\n    Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")),\n    Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
+    query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n|join kind=leftouter (itsgcodes) on itsgcode_s\n| project ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="False","(R) ", "(M) "), column_ifexists("ItemName_s", "")),\n    Comments=column_ifexists("Comments_s", ""),\n    Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'),\n    ["ITSG Control"]=column_ifexists("itsgcode_s", ""),\n    Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")),\n    Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
     functionAlias: 'gr_data3'
     functionParameters: 'ctrlprefix:string, ReportTime:string, showNonRequired:string'
     version: 2
@@ -920,7 +920,7 @@ resource f3 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-08-01' 
   properties: {
     category: 'gr_functions'
     displayName: 'gr_data567'
-    query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n| where TimeGenerated > ago (24h)\n|join kind=leftouter (itsgcodes) on itsgcode_s\n| extend SubscriptionName = coalesce(column_ifexists("SubscriptionName_s", ""), iff(column_ifexists("Type_s", "") == "subscription", column_ifexists("DisplayName_s", ""), ""))\n| project ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="false","(R) ", "(M) "), column_ifexists("ItemName_s", "")),\n    ["Subscription Name"]=SubscriptionName,\n    Comments=column_ifexists("Comments_s", ""),\n    Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'),\n    ["ITSG Control"]=column_ifexists("itsgcode_s", ""),\n    Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")),\n    Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
+    query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n|join kind=leftouter (itsgcodes) on itsgcode_s\n| extend SubscriptionName = coalesce(column_ifexists("SubscriptionName_s", ""), iff(column_ifexists("Type_s", "") == "subscription", column_ifexists("DisplayName_s", ""), ""))\n| project ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="false","(R) ", "(M) "), column_ifexists("ItemName_s", "")),\n    ["Subscription Name"]=SubscriptionName,\n    Comments=column_ifexists("Comments_s", ""),\n    Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'),\n    ["ITSG Control"]=column_ifexists("itsgcode_s", ""),\n    Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")),\n    Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
     functionAlias: 'gr_data567'
     functionParameters: 'ctrlprefix:string, ReportTime:string, showNonRequired:string'
     version: 2
@@ -933,7 +933,7 @@ resource grdata56 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-0
     category: 'gr_functions'
     displayName: 'gr_data56'
     // Profile gating removed from this query so run output rows are shown as emitted.
-    query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n| where TimeGenerated > ago (24h)\n|join kind=leftouter (itsgcodes) on itsgcode_s\n| extend SubscriptionName = coalesce(column_ifexists("SubscriptionName_s", ""), iff(column_ifexists("Type_s", "") == "subscription", column_ifexists("DisplayName_s", ""), ""))\n| project ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="False","(R) ", "(M) "), column_ifexists("ItemName_s", "")),\n    ["Subscription Name"]=SubscriptionName,\n    Comments=column_ifexists("Comments_s", ""),\n    Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'),\n    ["ITSG Control"]=column_ifexists("itsgcode_s", ""),\n    Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")),\n    Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
+    query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n|join kind=leftouter (itsgcodes) on itsgcode_s\n| extend SubscriptionName = coalesce(column_ifexists("SubscriptionName_s", ""), iff(column_ifexists("Type_s", "") == "subscription", column_ifexists("DisplayName_s", ""), ""))\n| project ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="False","(R) ", "(M) "), column_ifexists("ItemName_s", "")),\n    ["Subscription Name"]=SubscriptionName,\n    Comments=column_ifexists("Comments_s", ""),\n    Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'),\n    ["ITSG Control"]=column_ifexists("itsgcode_s", ""),\n    Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")),\n    Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
     functionAlias: 'gr_data56'
     functionParameters: 'ctrlprefix:string, ReportTime:string, showNonRequired:string'
     version: 2
@@ -946,7 +946,7 @@ resource grdata7 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-08
     category: 'gr_functions'
     displayName: 'gr_data7'
     // Profile gating removed from this query so valid profile rows are not suppressed.
-    query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n| where TimeGenerated > ago (24h)\n|join kind=leftouter (itsgcodes) on itsgcode_s\n| extend SubscriptionName = coalesce(column_ifexists("SubscriptionName_s", ""), iff(column_ifexists("Type_s", "") == "subscription", column_ifexists("DisplayName_s", ""), ""))\n| project ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="False","(R) ", "(M) "), column_ifexists("ItemName_s", "")),\n    ["Subscription Name"]=SubscriptionName,\n    Comments=column_ifexists("Comments_s", ""),\n    Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'),\n    ["ITSG Control"]=column_ifexists("itsgcode_s", ""),\n    Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")),\n    Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
+    query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n|join kind=leftouter (itsgcodes) on itsgcode_s\n| extend SubscriptionName = coalesce(column_ifexists("SubscriptionName_s", ""), iff(column_ifexists("Type_s", "") == "subscription", column_ifexists("DisplayName_s", ""), ""))\n| project ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="False","(R) ", "(M) "), column_ifexists("ItemName_s", "")),\n    ["Subscription Name"]=SubscriptionName,\n    Comments=column_ifexists("Comments_s", ""),\n    Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'),\n    ["ITSG Control"]=column_ifexists("itsgcode_s", ""),\n    Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")),\n    Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
     functionAlias: 'gr_data7'
     functionParameters: 'ctrlprefix:string, ReportTime:string, showNonRequired:string'
     version: 2
@@ -959,7 +959,7 @@ resource grdata9 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-08
     category: 'gr_functions'
     displayName: 'gr_data9'
     // Profile gating removed from this query so valid profile rows are not suppressed.
-    query: 'let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\n GuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix  and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n| where TimeGenerated > ago (24h)\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="False","(R) ", "(M) "), column_ifexists("ItemName_s", "")),\n ["Subscription Name"]=column_ifexists("SubscriptionName_s", ""), Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'), Comments=column_ifexists("Comments_s", ""), ["ITSG Control"]=column_ifexists("itsgcode_s", ""), Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")), Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
+    query: 'let itsgcodes=GRITSGControls_CL | where TimeGenerated == toscalar(GRITSGControls_CL | summarize by TimeGenerated | top 2 by TimeGenerated desc | top 1 by TimeGenerated asc | project TimeGenerated);\n GuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix  and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n|join kind=leftouter (itsgcodes) on itsgcode_s\r\n| project ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="False","(R) ", "(M) "), column_ifexists("ItemName_s", "")),\n ["Subscription Name"]=column_ifexists("SubscriptionName_s", ""), Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'), Comments=column_ifexists("Comments_s", ""), ["ITSG Control"]=column_ifexists("itsgcode_s", ""), Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")), Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
     functionAlias: 'gr_data9'
     functionParameters: 'ctrlprefix:string, ReportTime:string, showNonRequired:string'
     version: 2
@@ -971,7 +971,7 @@ resource f4 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-08-01' 
   properties: {
     category: 'gr_functions'
     displayName: 'gr_data11'
-    query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n| where TimeGenerated > ago (24h)\n|join kind=leftouter (itsgcodes) on itsgcode_s\n| project  ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="false","(R) ", "(M) "), column_ifexists("ItemName_s", "")), ["Subscription Name"] = column_ifexists("SubscriptionName_s", ""), Comments=column_ifexists("Comments_s", ""), Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'),["ITSG Control"]=column_ifexists("itsgcode_s", ""), Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")), Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
+    query: 'let itsgcodes=GRITSGControls_CL | summarize arg_max(TimeGenerated, *) by itsgcode_s;\nGuardrailsCompliance_CL\n| where column_ifexists("ControlName_s", "") has ctrlprefix and column_ifexists("ReportTime_s", "") == ReportTime and column_ifexists("Required_s", "") != tostring(showNonRequired)\n|join kind=leftouter (itsgcodes) on itsgcode_s\n| project  ["Item Name"]=strcat(iff(column_ifexists("Required_s", "")=="false","(R) ", "(M) "), column_ifexists("ItemName_s", "")), ["Subscription Name"] = column_ifexists("SubscriptionName_s", ""), Comments=column_ifexists("Comments_s", ""), Status=case(column_ifexists("ComplianceStatus_b", bool(null)) == true, \'✔️\', column_ifexists("ComplianceStatus_b", bool(null)) == false, \'❌\', \'➖\'),["ITSG Control"]=column_ifexists("itsgcode_s", ""), Remediation=gr_geturl(replace_string(ctrlprefix," ",""),column_ifexists("itsgcode_s", "")), Profile=iff(isnotempty(column_ifexists("Profile_d", "")), tostring(toint(column_ifexists("Profile_d", ""))), "")\n'
     functionAlias: 'gr_data11'
     functionParameters: 'ctrlprefix:string, ReportTime:string, showNonRequired:string'
     version: 2
@@ -1379,9 +1379,9 @@ resource grSummaryByPrefix 'Microsoft.OperationalInsights/workspaces/savedSearch
     //  - ReportTime: exact report timestamp (string) to match records
     //  - TimeWindowHours: lookback window in hours
     //  - showNonRequired: string toggle; when "False", only mandatory (Required_s == "True")
-    query: 'let windowHours = toint(TimeWindowHours);\nlet base = GuardrailsCompliance_CL\n| where TimeGenerated > ago(windowHours * 1h)\n| where column_ifexists("ReportTime_s","") == ReportTime\n| where column_ifexists("ControlName_s","") has Guardrail\n| where isempty(showIfRequired) or column_ifexists("Required_s","") == tostring(showIfRequired);\nbase\n| extend ComplianceStatus = column_ifexists("ComplianceStatus_b", bool(null))\n| summarize TotalControls = count(), NonCompliantItems = countif(ComplianceStatus == false), UnknownItems = countif(isnull(ComplianceStatus))\n| extend HasNonCompliance = NonCompliantItems > 0\n| extend Status = iff(HasNonCompliance, "❌", "✔️")\n| project Guardrail, ["Total # Items"]=TotalControls, ["NonCompliant Items"]=NonCompliantItems, ["Unknown Items"]=UnknownItems, Status'
+    query: 'let base = GuardrailsCompliance_CL\n| where column_ifexists("ReportTime_s","") == ReportTime\n| where column_ifexists("ControlName_s","") has Guardrail\n| where isempty(showIfRequired) or column_ifexists("Required_s","") == tostring(showIfRequired);\nbase\n| extend ComplianceStatus = column_ifexists("ComplianceStatus_b", bool(null))\n| summarize TotalControls = count(), NonCompliantItems = countif(ComplianceStatus == false), UnknownItems = countif(isnull(ComplianceStatus))\n| extend HasNonCompliance = NonCompliantItems > 0\n| extend Status = iff(HasNonCompliance, "❌", "✔️")\n| project Guardrail, ["Total # Items"]=TotalControls, ["NonCompliant Items"]=NonCompliantItems, ["Unknown Items"]=UnknownItems, Status'
     functionAlias: 'gr_summary_by_prefix'
-    functionParameters: 'Guardrail:string, ReportTime:string, TimeWindowHours:int, showIfRequired:string'
+    functionParameters: 'Guardrail:string, ReportTime:string, showIfRequired:string'
     version: 2 
   }
 }
@@ -1392,9 +1392,9 @@ resource grSummaryByPrefixa 'Microsoft.OperationalInsights/workspaces/savedSearc
     category: 'gr_functions'
     displayName: 'gr_summary_by_prefix_a'
     // KQL function: summarize per Guardrail, nonCompliant number includes both mandatory and recommended controls, but status only reflects mandatory controls
-    query: 'let windowHours = toint(TimeWindowHours);\nlet base = GuardrailsCompliance_CL\n| where TimeGenerated > ago(windowHours * 1h)\n| where column_ifexists("ReportTime_s","") == ReportTime\n| where column_ifexists("ControlName_s","") has Guardrail\n| where isempty(showIfRequired) or column_ifexists("Required_s","") == tostring(showIfRequired);\nbase\n| extend ComplianceStatus = column_ifexists("ComplianceStatus_b", bool(null))\n| summarize TotalControls = count(), NonCompliantItems = countif(ComplianceStatus == false), NonCompliantItems1 = countif(ComplianceStatus == false  and column_ifexists("Required_s","") == "True"), UnknownItems = countif(isnull(ComplianceStatus))\n| extend HasNonCompliance = NonCompliantItems1 > 0\n| extend Status = iff(HasNonCompliance, "❌", "✔️")\n| project Guardrail, ["Total # Items"]=TotalControls, ["NonCompliant Items"]=NonCompliantItems, ["Unknown Items"]=UnknownItems, Status'
+    query: 'let base = GuardrailsCompliance_CL\n| where column_ifexists("ReportTime_s","") == ReportTime\n| where column_ifexists("ControlName_s","") has Guardrail\n| where isempty(showIfRequired) or column_ifexists("Required_s","") == tostring(showIfRequired);\nbase\n| extend ComplianceStatus = column_ifexists("ComplianceStatus_b", bool(null))\n| summarize TotalControls = count(), NonCompliantItems = countif(ComplianceStatus == false), NonCompliantItems1 = countif(ComplianceStatus == false  and column_ifexists("Required_s","") == "True"), UnknownItems = countif(isnull(ComplianceStatus))\n| extend HasNonCompliance = NonCompliantItems1 > 0\n| extend Status = iff(HasNonCompliance, "❌", "✔️")\n| project Guardrail, ["Total # Items"]=TotalControls, ["NonCompliant Items"]=NonCompliantItems, ["Unknown Items"]=UnknownItems, Status'
     functionAlias: 'gr_summary_by_prefix_a'
-    functionParameters: 'Guardrail:string, ReportTime:string, TimeWindowHours:int, showIfRequired:string'
+    functionParameters: 'Guardrail:string, ReportTime:string, showIfRequired:string'
     version: 2 
   }
 }
@@ -1410,9 +1410,9 @@ resource grSummaryByPrefix3 'Microsoft.OperationalInsights/workspaces/savedSearc
     //  - TimeWindowHours: lookback window in hours
     //  - showNonRequired: string toggle; when "False", only mandatory (Required_s == "True")
     // Profile gating removed from this query to keep summary totals aligned to emitted rows.
-    query: 'let windowHours = toint(TimeWindowHours);\nlet base = GuardrailsCompliance_CL\n| where TimeGenerated > ago(windowHours * 1h)\n| where column_ifexists("ReportTime_s","") == ReportTime\n| where column_ifexists("ControlName_s","") has Guardrail\n| where isempty(showIfRequired) or column_ifexists("Required_s","") == tostring(showIfRequired);\nbase\n| extend ComplianceStatus = column_ifexists("ComplianceStatus_b", bool(null))\n| summarize TotalControls = count(), NonCompliantItems = countif(ComplianceStatus == false), UnknownItems = countif(isnull(ComplianceStatus))\n| extend HasNonCompliance = NonCompliantItems > 0\n| extend Status = iff(HasNonCompliance, "❌", "✔️")\n| project Guardrail, ["Total # Items"]=TotalControls, ["NonCompliant Items"]=NonCompliantItems, ["Unknown Items"]=UnknownItems, Status'
+    query: 'let base = GuardrailsCompliance_CL\n| where column_ifexists("ReportTime_s","") == ReportTime\n| where column_ifexists("ControlName_s","") has Guardrail\n| where isempty(showIfRequired) or column_ifexists("Required_s","") == tostring(showIfRequired);\nbase\n| extend ComplianceStatus = column_ifexists("ComplianceStatus_b", bool(null))\n| summarize TotalControls = count(), NonCompliantItems = countif(ComplianceStatus == false), UnknownItems = countif(isnull(ComplianceStatus))\n| extend HasNonCompliance = NonCompliantItems > 0\n| extend Status = iff(HasNonCompliance, "❌", "✔️")\n| project Guardrail, ["Total # Items"]=TotalControls, ["NonCompliant Items"]=NonCompliantItems, ["Unknown Items"]=UnknownItems, Status'
     functionAlias: 'gr_summary_by_prefix3'
-    functionParameters: 'Guardrail:string, ReportTime:string, TimeWindowHours:int, showIfRequired:string'
+    functionParameters: 'Guardrail:string, ReportTime:string, showIfRequired:string'
     version: 2 
   }
 }
@@ -1429,9 +1429,9 @@ resource grSummaryByPrefix3a 'Microsoft.OperationalInsights/workspaces/savedSear
     //  - showNonRequired: string toggle; when "False", only mandatory (Required_s == "True")
     // status only reflects mandatory controls
     // Profile gating removed from this query to keep summary totals aligned to emitted rows.
-    query: 'let windowHours = toint(TimeWindowHours);\nlet base = GuardrailsCompliance_CL\n| where TimeGenerated > ago(windowHours * 1h)\n| where column_ifexists("ReportTime_s","") == ReportTime\n| where column_ifexists("ControlName_s","") has Guardrail\n| where isempty(showIfRequired) or column_ifexists("Required_s","") == tostring(showIfRequired);\nbase\n| extend ComplianceStatus = column_ifexists("ComplianceStatus_b", bool(null))\n| summarize TotalControls = count(), NonCompliantItems = countif(ComplianceStatus == false), NonCompliantItems1 = countif(ComplianceStatus == false and column_ifexists("Required_s","") == "True"), UnknownItems = countif(isnull(ComplianceStatus))\n| extend HasNonCompliance = NonCompliantItems1 > 0\n| extend Status = iff(HasNonCompliance, "❌", "✔️")\n| project Guardrail, ["Total # Items"]=TotalControls, ["NonCompliant Items"]=NonCompliantItems, ["Unknown Items"]=UnknownItems, Status'
+    query: 'let base = GuardrailsCompliance_CL\n| where column_ifexists("ReportTime_s","") == ReportTime\n| where column_ifexists("ControlName_s","") has Guardrail\n| where isempty(showIfRequired) or column_ifexists("Required_s","") == tostring(showIfRequired);\nbase\n| extend ComplianceStatus = column_ifexists("ComplianceStatus_b", bool(null))\n| summarize TotalControls = count(), NonCompliantItems = countif(ComplianceStatus == false), NonCompliantItems1 = countif(ComplianceStatus == false and column_ifexists("Required_s","") == "True"), UnknownItems = countif(isnull(ComplianceStatus))\n| extend HasNonCompliance = NonCompliantItems1 > 0\n| extend Status = iff(HasNonCompliance, "❌", "✔️")\n| project Guardrail, ["Total # Items"]=TotalControls, ["NonCompliant Items"]=NonCompliantItems, ["Unknown Items"]=UnknownItems, Status'
     functionAlias: 'gr_summary_by_prefix3a'
-    functionParameters: 'Guardrail:string, ReportTime:string, TimeWindowHours:int, showIfRequired:string'
+    functionParameters: 'Guardrail:string, ReportTime:string, showIfRequired:string'
     version: 2 
   }
 }
@@ -1447,9 +1447,9 @@ resource grSummaryByPrefix56 'Microsoft.OperationalInsights/workspaces/savedSear
     //  - TimeWindowHours: lookback window in hours
     //  - showNonRequired: string toggle; when "False", only mandatory (Required_s == "True")
     // Profile gating removed from this query to keep summary totals aligned to emitted rows.
-    query: 'let windowHours = toint(TimeWindowHours);\nlet base = GuardrailsCompliance_CL\n| where TimeGenerated > ago(windowHours * 1h)\n| where column_ifexists("ReportTime_s","") == ReportTime\n| where column_ifexists("ControlName_s","") has Guardrail\n| where isempty(showIfRequired) or column_ifexists("Required_s","") == tostring(showIfRequired);\nbase\n| extend ComplianceStatus = column_ifexists("ComplianceStatus_b", bool(null))\n| summarize TotalControls = count(), NonCompliantItems = countif(ComplianceStatus == false), UnknownItems = countif(isnull(ComplianceStatus))\n| extend HasNonCompliance = NonCompliantItems > 0\n| extend Status = iff(HasNonCompliance, "❌", "✔️")\n| project Guardrail, ["Total # Items"]=TotalControls, ["NonCompliant Items"]=NonCompliantItems, ["Unknown Items"]=UnknownItems, Status'
+    query: 'let base = GuardrailsCompliance_CL\n| where column_ifexists("ReportTime_s","") == ReportTime\n| where column_ifexists("ControlName_s","") has Guardrail\n| where isempty(showIfRequired) or column_ifexists("Required_s","") == tostring(showIfRequired);\nbase\n| extend ComplianceStatus = column_ifexists("ComplianceStatus_b", bool(null))\n| summarize TotalControls = count(), NonCompliantItems = countif(ComplianceStatus == false), UnknownItems = countif(isnull(ComplianceStatus))\n| extend HasNonCompliance = NonCompliantItems > 0\n| extend Status = iff(HasNonCompliance, "❌", "✔️")\n| project Guardrail, ["Total # Items"]=TotalControls, ["NonCompliant Items"]=NonCompliantItems, ["Unknown Items"]=UnknownItems, Status'
     functionAlias: 'gr_summary_by_prefix56'
-    functionParameters: 'Guardrail:string, ReportTime:string, TimeWindowHours:int, showIfRequired:string'
+    functionParameters: 'Guardrail:string, ReportTime:string, showIfRequired:string'
     version: 2 
   }
 }
@@ -1466,9 +1466,9 @@ resource grSummaryByPrefix56a 'Microsoft.OperationalInsights/workspaces/savedSea
     //  - showNonRequired: string toggle; when "False", only mandatory (Required_s == "True")
     // status only reflects mandatory controls
     // Profile gating removed from this query to keep summary totals aligned to emitted rows.
-    query: 'let windowHours = toint(TimeWindowHours);\nlet base = GuardrailsCompliance_CL\n| where TimeGenerated > ago(windowHours * 1h)\n| where column_ifexists("ReportTime_s","") == ReportTime\n| where column_ifexists("ControlName_s","") has Guardrail\n| where isempty(showIfRequired) or column_ifexists("Required_s","") == tostring(showIfRequired);\nbase\n| extend ComplianceStatus = column_ifexists("ComplianceStatus_b", bool(null))\n| summarize TotalControls = count(), NonCompliantItems = countif(ComplianceStatus == false), NonCompliantItems1 = countif(ComplianceStatus == false and column_ifexists("Required_s","") == "True"), UnknownItems = countif(isnull(ComplianceStatus))\n| extend HasNonCompliance = NonCompliantItems1 > 0\n| extend Status = iff(HasNonCompliance, "❌", "✔️")\n| project Guardrail, ["Total # Items"]=TotalControls, ["NonCompliant Items"]=NonCompliantItems, ["Unknown Items"]=UnknownItems, Status'
+    query: 'let base = GuardrailsCompliance_CL\n| where column_ifexists("ReportTime_s","") == ReportTime\n| where column_ifexists("ControlName_s","") has Guardrail\n| where isempty(showIfRequired) or column_ifexists("Required_s","") == tostring(showIfRequired);\nbase\n| extend ComplianceStatus = column_ifexists("ComplianceStatus_b", bool(null))\n| summarize TotalControls = count(), NonCompliantItems = countif(ComplianceStatus == false), NonCompliantItems1 = countif(ComplianceStatus == false and column_ifexists("Required_s","") == "True"), UnknownItems = countif(isnull(ComplianceStatus))\n| extend HasNonCompliance = NonCompliantItems1 > 0\n| extend Status = iff(HasNonCompliance, "❌", "✔️")\n| project Guardrail, ["Total # Items"]=TotalControls, ["NonCompliant Items"]=NonCompliantItems, ["Unknown Items"]=UnknownItems, Status'
     functionAlias: 'gr_summary_by_prefix56a'
-    functionParameters: 'Guardrail:string, ReportTime:string, TimeWindowHours:int, showIfRequired:string'
+    functionParameters: 'Guardrail:string, ReportTime:string, showIfRequired:string'
     version: 2 
   }
 }
@@ -1484,23 +1484,23 @@ resource grSummaryByPrefixAll 'Microsoft.OperationalInsights/workspaces/savedSea
     //  - showIfRequired: string toggle; when "False", only mandatory (Required_s == "True")
     query: '''
 union
-    gr_summary_by_prefix("GUARDRAIL 1", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix("GUARDRAIL 2", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix3("GUARDRAIL 3", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix("GUARDRAIL 4", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix56("GUARDRAIL 5", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix56("GUARDRAIL 6", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix3("GUARDRAIL 7", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix("GUARDRAIL 8", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix3("GUARDRAIL 9", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix3("GUARDRAIL 10", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix3("GUARDRAIL 11", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix("GUARDRAIL 12", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix3("GUARDRAIL 13", ReportTime, TimeWindowHours, showIfRequired)
+    gr_summary_by_prefix("GUARDRAIL 1", ReportTime, showIfRequired),
+    gr_summary_by_prefix("GUARDRAIL 2", ReportTime, showIfRequired),
+    gr_summary_by_prefix3("GUARDRAIL 3", ReportTime, showIfRequired),
+    gr_summary_by_prefix("GUARDRAIL 4", ReportTime, showIfRequired),
+    gr_summary_by_prefix56("GUARDRAIL 5", ReportTime, showIfRequired),
+    gr_summary_by_prefix56("GUARDRAIL 6", ReportTime, showIfRequired),
+    gr_summary_by_prefix3("GUARDRAIL 7", ReportTime, showIfRequired),
+    gr_summary_by_prefix("GUARDRAIL 8", ReportTime, showIfRequired),
+    gr_summary_by_prefix3("GUARDRAIL 9", ReportTime, showIfRequired),
+    gr_summary_by_prefix3("GUARDRAIL 10", ReportTime, showIfRequired),
+    gr_summary_by_prefix3("GUARDRAIL 11", ReportTime, showIfRequired),
+    gr_summary_by_prefix("GUARDRAIL 12", ReportTime, showIfRequired),
+    gr_summary_by_prefix3("GUARDRAIL 13", ReportTime, showIfRequired)
 | order by toint(extract(@"\d+", 0, Guardrail)) asc
 '''
     functionAlias: 'gr_summary_by_prefix_all'
-    functionParameters: 'ReportTime:string, TimeWindowHours:int, showIfRequired:string'
+    functionParameters: 'ReportTime:string, showIfRequired:string'
     version: 2
   }
 }
@@ -1517,23 +1517,23 @@ resource grSummaryByPrefixAlla 'Microsoft.OperationalInsights/workspaces/savedSe
     // status only reflects mandatory controls
     query: '''
 union
-    gr_summary_by_prefix_a("GUARDRAIL 1", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix_a("GUARDRAIL 2", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix3a("GUARDRAIL 3", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix_a("GUARDRAIL 4", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix56a("GUARDRAIL 5", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix56a("GUARDRAIL 6", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix3a("GUARDRAIL 7", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix_a("GUARDRAIL 8", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix3a("GUARDRAIL 9", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix3a("GUARDRAIL 10", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix3a("GUARDRAIL 11", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix_a("GUARDRAIL 12", ReportTime, TimeWindowHours, showIfRequired),
-    gr_summary_by_prefix3a("GUARDRAIL 13", ReportTime, TimeWindowHours, showIfRequired)
+    gr_summary_by_prefix_a("GUARDRAIL 1", ReportTime, showIfRequired),
+    gr_summary_by_prefix_a("GUARDRAIL 2", ReportTime, showIfRequired),
+    gr_summary_by_prefix3a("GUARDRAIL 3", ReportTime, showIfRequired),
+    gr_summary_by_prefix_a("GUARDRAIL 4", ReportTime, showIfRequired),
+    gr_summary_by_prefix56a("GUARDRAIL 5", ReportTime, showIfRequired),
+    gr_summary_by_prefix56a("GUARDRAIL 6", ReportTime, showIfRequired),
+    gr_summary_by_prefix3a("GUARDRAIL 7", ReportTime, showIfRequired),
+    gr_summary_by_prefix_a("GUARDRAIL 8", ReportTime, showIfRequired),
+    gr_summary_by_prefix3a("GUARDRAIL 9", ReportTime, showIfRequired),
+    gr_summary_by_prefix3a("GUARDRAIL 10", ReportTime, showIfRequired),
+    gr_summary_by_prefix3a("GUARDRAIL 11", ReportTime, showIfRequired),
+    gr_summary_by_prefix_a("GUARDRAIL 12", ReportTime, showIfRequired),
+    gr_summary_by_prefix3a("GUARDRAIL 13", ReportTime, showIfRequired)
 | order by toint(extract(@"\d+", 0, Guardrail)) asc
 '''
     functionAlias: 'gr_summary_by_prefix_alla'
-    functionParameters: 'ReportTime:string, TimeWindowHours:int, showIfRequired:string'
+    functionParameters: 'ReportTime:string, showIfRequired:string'
     version: 2
   }
 }
@@ -1547,19 +1547,19 @@ resource grSummaryAll 'Microsoft.OperationalInsights/workspaces/savedSearches@20
     // status only reflects mandatory controls
     query: '''
 union isfuzzy=true
-  (gr_summary_by_prefix_a("GUARDRAIL 1",  ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix_a("GUARDRAIL 2",  ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3a("GUARDRAIL 3", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix_a("GUARDRAIL 4",  ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix56a("GUARDRAIL 5", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix56a("GUARDRAIL 6", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3a("GUARDRAIL 7", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix_a("GUARDRAIL 8",  ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3a("GUARDRAIL 9", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3a("GUARDRAIL 10", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3a("GUARDRAIL 11", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix_a("GUARDRAIL 12", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3a("GUARDRAIL 13", ReportTime, TimeWindowHours, showIfRequired))
+  (gr_summary_by_prefix_a("GUARDRAIL 1",  ReportTime, showIfRequired)),
+  (gr_summary_by_prefix_a("GUARDRAIL 2",  ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3a("GUARDRAIL 3", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix_a("GUARDRAIL 4",  ReportTime, showIfRequired)),
+  (gr_summary_by_prefix56a("GUARDRAIL 5", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix56a("GUARDRAIL 6", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3a("GUARDRAIL 7", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix_a("GUARDRAIL 8",  ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3a("GUARDRAIL 9", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3a("GUARDRAIL 10", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3a("GUARDRAIL 11", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix_a("GUARDRAIL 12", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3a("GUARDRAIL 13", ReportTime, showIfRequired))
 | project
     TotalControls_norm     = tolong(column_ifexists("TotalControls",      column_ifexists("Total # Items", 0))),
     NonCompliantItems_norm = tolong(column_ifexists("NonCompliantItems",  column_ifexists("NonCompliant Items", 0))),
@@ -1579,7 +1579,7 @@ union isfuzzy=true
 
 
     functionAlias: 'gr_summary_all'
-    functionParameters: 'ReportTime:string, TimeWindowHours:int, showIfRequired:string'
+    functionParameters: 'ReportTime:string, showIfRequired:string'
     version: 2
   }
 }
@@ -1595,19 +1595,19 @@ resource grSummaryMandatory 'Microsoft.OperationalInsights/workspaces/savedSearc
     //  - showIfRequired: string toggle; when "False", only mandatory (Required_s == "True")
     query: '''
 union isfuzzy=true
-  (gr_summary_by_prefix("GUARDRAIL 1",  ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix("GUARDRAIL 2",  ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3("GUARDRAIL 3", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix("GUARDRAIL 4",  ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix56("GUARDRAIL 5", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix56("GUARDRAIL 6", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3("GUARDRAIL 7", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix("GUARDRAIL 8",  ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3("GUARDRAIL 9", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3("GUARDRAIL 10", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3("GUARDRAIL 11", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix("GUARDRAIL 12", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3("GUARDRAIL 13", ReportTime, TimeWindowHours, showIfRequired))
+  (gr_summary_by_prefix("GUARDRAIL 1",  ReportTime, showIfRequired)),
+  (gr_summary_by_prefix("GUARDRAIL 2",  ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3("GUARDRAIL 3", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix("GUARDRAIL 4",  ReportTime, showIfRequired)),
+  (gr_summary_by_prefix56("GUARDRAIL 5", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix56("GUARDRAIL 6", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3("GUARDRAIL 7", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix("GUARDRAIL 8",  ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3("GUARDRAIL 9", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3("GUARDRAIL 10", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3("GUARDRAIL 11", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix("GUARDRAIL 12", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3("GUARDRAIL 13", ReportTime, showIfRequired))
 | project
     TotalControls_norm     = tolong(column_ifexists("TotalControls",      column_ifexists("Total # Items", 0))),
     NonCompliantItems_norm = tolong(column_ifexists("NonCompliantItems",  column_ifexists("NonCompliant Items", 0))),
@@ -1627,7 +1627,7 @@ union isfuzzy=true
 
 
     functionAlias: 'gr_summary_mandatory'
-    functionParameters: 'ReportTime:string, TimeWindowHours:int, showIfRequired:string'
+    functionParameters: 'ReportTime:string, showIfRequired:string'
     version: 2
   }
 }
@@ -1644,19 +1644,19 @@ resource grSummaryRecommended 'Microsoft.OperationalInsights/workspaces/savedSea
     //  - showIfRequired: string toggle; when "False", only mandatory (Required_s == "True")
     query: '''
 union isfuzzy=true
-  (gr_summary_by_prefix("GUARDRAIL 1",  ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix("GUARDRAIL 2",  ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3("GUARDRAIL 3", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix("GUARDRAIL 4",  ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix56("GUARDRAIL 5", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix56("GUARDRAIL 6", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3("GUARDRAIL 7", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix("GUARDRAIL 8",  ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3("GUARDRAIL 9", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3("GUARDRAIL 10", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3("GUARDRAIL 11", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix("GUARDRAIL 12", ReportTime, TimeWindowHours, showIfRequired)),
-  (gr_summary_by_prefix3("GUARDRAIL 13", ReportTime, TimeWindowHours, showIfRequired))
+  (gr_summary_by_prefix("GUARDRAIL 1",  ReportTime, showIfRequired)),
+  (gr_summary_by_prefix("GUARDRAIL 2",  ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3("GUARDRAIL 3", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix("GUARDRAIL 4",  ReportTime, showIfRequired)),
+  (gr_summary_by_prefix56("GUARDRAIL 5", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix56("GUARDRAIL 6", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3("GUARDRAIL 7", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix("GUARDRAIL 8",  ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3("GUARDRAIL 9", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3("GUARDRAIL 10", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3("GUARDRAIL 11", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix("GUARDRAIL 12", ReportTime, showIfRequired)),
+  (gr_summary_by_prefix3("GUARDRAIL 13", ReportTime, showIfRequired))
 | project
     TotalControls_norm     = tolong(column_ifexists("TotalControls",      column_ifexists("Total # Items", 0))),
     NonCompliantItems_norm = tolong(column_ifexists("NonCompliantItems",  column_ifexists("NonCompliant Items", 0))),
@@ -1676,7 +1676,7 @@ union isfuzzy=true
 
 
     functionAlias: 'gr_summary_recommended'
-    functionParameters: 'ReportTime:string, TimeWindowHours:int, showIfRequired:string'
+    functionParameters: 'ReportTime:string, showIfRequired:string'
     version: 2
   }
 }
@@ -1692,12 +1692,12 @@ resource grSummary 'Microsoft.OperationalInsights/workspaces/savedSearches@2020-
     //  - showIfRequired: string toggle; when "False", only mandatory (Required_s == "True")
     query: '''
 union
-    gr_summary_all(ReportTime, TimeWindowHours, ""),
-    gr_summary_mandatory(ReportTime, TimeWindowHours, true),
-    gr_summary_recommended(ReportTime, TimeWindowHours, false)
+    gr_summary_all(ReportTime, ""),
+    gr_summary_mandatory(ReportTime, true),
+    gr_summary_recommended(ReportTime, false)
 '''
     functionAlias: 'gr_summary'
-    functionParameters: 'ReportTime:string, TimeWindowHours:int'
+    functionParameters: 'ReportTime:string'
     version: 2
   }
 }


### PR DESCRIPTION
## Overview/Summary

The PR is to fix the bug in report query function. It was only allowing to query the reports generated in 24 hours regardless if select other days in the report time dropdown in Workbook UI. Now the query function has been modified to allow to query any time without the 24 hours limit.

## This PR fixes/adds/changes/removes

1. Modify [loganalyticsworkspace.bicep](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/blob/release/4.0.0/setup/IaC/modules/loganalyticsworkspace.bicep) to remove 24 hours limit in all query functions 
2. Modify [gr.workbook](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/blob/release/4.0.0/setup/IaC/modules/gr.workbook) to allow all guardrails to show reports in 30 days instead of 24 hours

## Breaking Changes

N/A

## Disclosure of AI assistance

Please provide a brief descriptio if any AI-assisted code is used in this PR and the nature and extent of the AI assistance e.g. file name, line numbers etc.


## Testing Evidence

<img width="538" height="725" alt="Screenshot 2026-07-10 115247" src="https://github.com/user-attachments/assets/dbafd2d5-12e0-4a20-b025-7ce2a438951f" />
<img width="496" height="711" alt="Screenshot 2026-07-10 115301" src="https://github.com/user-attachments/assets/06c32ffc-6744-4cf7-9d9b-4fbca38dcb92" />
<img width="686" height="791" alt="Screenshot 2026-07-10 115141" src="https://github.com/user-attachments/assets/8aac7ef4-949d-40a8-8948-ec213554309e" />
<img width="751" height="776" alt="Screenshot 2026-07-10 115156" src="https://github.com/user-attachments/assets/16b87be3-89c1-47bc-a360-37eba2efce82" />

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main) or associated `release` branch.
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
