### PR TITLE
[Bugfix] Dev deploy release time fix

### DIFF
--- a/.github/workflows/deploy_dev_env.yml
+++ b/.github/workflows/deploy_dev_env.yml
@@ -19,12 +19,17 @@ env:
 
 jobs:
   sign-scripts:
+    # Automatic deployments should run only after a successful release. Manual runs remain available.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     name: Validate, test and publish Powershell scripts as pipeline artifacts
     runs-on: windows-latest
     environment: test
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+          # Automatic runs use the released commit; manual runs use the branch selected in GitHub.
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
       - name: Test Module Imports
         shell: powershell
         run: |
@@ -86,6 +91,9 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v3
+        with:
+          # Use the same source for deployment that was used to build the module artifacts above.
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
       - name: Download zipped modules and replace old ones
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Overview/Summary

When dev deployment kicks off at release time, it deploys the main branch instead of the release tag.
This fixes that issue.

## This PR fixes/adds/changes/removes

Deploy the actual release instead of main.

## Breaking Changes

N/A

## Disclosure of AI assistance

N/A


## Testing Evidence

Dev workflow tested and deploys fine.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main) or associated `release` branch.
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
