### PR TITLE
[Enhancement] Set row limit to 1500 for main branch

### DIFF
--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -1000,6 +1000,7 @@
               }
             }
           ],
+          "rowLimit": 1500,
           "hierarchySettings": {
             "treeType": 1,
             "groupBy": [
@@ -1141,6 +1142,7 @@
               }
             }
           ],
+          "rowLimit": 1500,
           "hierarchySettings": {
             "treeType": 1,
             "groupBy": [
@@ -1281,6 +1283,7 @@
               }
             }
           ],
+          "rowLimit": 1500,
           "hierarchySettings": {
             "treeType": 1,
             "groupBy": [
@@ -1421,6 +1424,7 @@
               }
             }
           ],
+          "rowLimit": 1500,
           "hierarchySettings": {
             "treeType": 1,
             "groupBy": [
@@ -1569,6 +1573,7 @@
               }
             }
           ],
+          "rowLimit": 1500,
           "hierarchySettings": {
             "treeType": 1,
             "groupBy": [
@@ -1859,6 +1864,7 @@
               }
             }
           ],
+          "rowLimit": 1500,
           "hierarchySettings": {
             "treeType": 1,
             "groupBy": [


### PR DESCRIPTION
## Overview/Summary

The change is to meet clients' requirement with very large tenants who frequently exceed 250 results for several guardrails.
The default Grid/Table visualization is 250 rows. Although we can increase the limit from Workbook UI advanced settings when need to show more rows, this change makes the default to 1500 rows without any manual setting change.

## This PR fixes/adds/changes/removes

Add setting: "rowLimit": 1500, for several guardrails in gr.workbook

## Breaking Changes
n/a

## Disclosure of AI assistance

Please provide a brief descriptio if any AI-assisted code is used in this PR and the nature and extent of the AI assistance e.g. file name, line numbers etc.


## Testing Evidence

<img width="783" height="187" alt="image" src="https://github.com/user-attachments/assets/e4e15d07-57da-4e2b-a74a-816b6849b301" />

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ssc-spc-ccoe-cei/azure-guardrails-solution-accelerator/tree/main) or associated `release` branch.
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
